### PR TITLE
Updates groeninge, msk, muzee fixes to work with latest Adlib changes, also renames Dutch keywords to English

### DIFF
--- a/datahub-oai-to-blacklight-solr-en.fix
+++ b/datahub-oai-to-blacklight-solr-en.fix
@@ -1,0 +1,1082 @@
+# Catmandu Fix script
+#
+# Convert data from the VKC Datahub to the VKC Arthub.
+#
+# This Fix script will take LIDO XML records as an input and transform
+# them into JSON objects that can be uploaded into an Apache Solr store.
+#
+# The Solr schema has been optimised for Project Blacklight (http://projectblacklight.org).
+# The JSON objects should conform to the schema.
+#
+# See: https://github.com/VlaamseKunstcollectie/Arthub-Frontend/tree/master/jetty/solr
+# 
+# Usage:
+#
+#  $ catmandu convert OAI --url "http://endpoint/oai/" --metadataPrefix oai_lido 
+#    --handler lido to JSON --pretty 1 --fix datahub-oai-to-blacklight-solr.fix > out.json
+#
+# In order to import data into the Solr core, create a pipeline and use the Datahub::Factory:
+#
+# see: 
+#
+# arthub.ini:
+#
+#    [Indexer]
+#    plugin = Solr
+#
+#    [plugin_indexer_Solr]
+#    file_name = '/tmp/bulk.json'
+#    request_handler = 'http://datahub.box:8983/solr/blacklight-core/update/json'
+#
+# Usage:
+#
+#  $ catmandu convert OAI --url http://datahub.box/oai --handler lido 
+#    to JSON --fix datahub-oai-to-blacklight-solr.fix > /tmp/bulk.json
+#  $ dhconveyor index -p ../pipelines/arthub.ini -v
+
+
+### Mapping between LIDO elements and Solr fields
+
+# Mapping
+# --------------------------------------------------------------------------
+# LIDO                                          Solr
+#                                                   id
+# lido:lidoRecID
+#   type: purl                                      data_pid
+# lido:objectPublishedID                            work_pid
+# lido:objectWorkType
+#   lido:term
+#       pref: preferred                             artwork_subtype_display
+#       pref: alternate                             artwork_subtype
+# lido:classification
+#   type: object-category
+#       lido:term
+#           pref: preferred                         artwork_type_display
+#           pref: alternate                         artwork_type  
+# lido:titleSet                                     
+#   pref: preferred                                 title_display
+# lido:workID
+#   type: object-number                             object_number
+# lido:objectDescriptionSet                         description
+# lido:objectMeasurementsSet
+#   lido:measurementsSet
+#       lido:extentMeasurements
+#           geheel                                  dimensions
+#
+#                                                   creator
+# lido:eventType
+#   lido:term
+#       production
+#           lido:eventActor
+#               lido:nameActorSet
+#                   pref: preferred                 creator_display
+#                   pref: alternate                 creator_index
+#               lido:roleActor                      creator_role
+#               lido:attributionQualifierActor      
+#           lido:eventDate
+#               lido:displayDate                    production_date
+#           lido:periodName
+#               lido:term
+#                   lang: nl                        period
+#           lido:termMaterialsTech
+#               type: material
+#                   lido:term
+#                       pref: preferred             material_display
+#                       pref: alternate             material
+# lido:objectRelationWrap
+#   lido:subject
+#       type: content-motif-general
+#           lido:subjectConcept
+#               lido:term
+#                   pref: preferred                 artwork_category_display
+#                   pref: alternate                 artwork_category
+# lido:recordWrap          
+#   lido:recordSource
+#       lido:legalBodyName                          repository
+# lido:resourceWrap
+#   lido:resourceSet
+#       lido:resourceID                             representation_pid
+#       lido:resourceRepresentation
+#   lido:resourceSet
+#       lido:resourceID                             manifest_url
+#       lido:resourceType
+#           lido:term
+#               IIIF Manifest
+#   lido:resourceSet
+#       lido:resourceID                             thumbnail_url
+#       lido:resourceType
+#           lido:term
+#               thumbnail
+#
+#                                                   publish_image          
+
+
+## DescriptiveMetadata
+
+# Copy field to filter on language
+
+do list(path:_metadata.descriptiveMetadata, var:dm)
+    if all_match('dm.lang', 'nl')
+        copy_field('dm', 'filteredDescriptiveMetadata')
+    end
+end
+
+
+## AdministrativeMetadata
+
+# Copy field to filter on language
+
+do list(path:_metadata.administrativeMetadata, var:am)
+    if all_match('am.lang', 'nl')
+        copy_field('am', 'filteredAdministrativeMetadata')
+    end
+end
+
+
+## Title
+
+# Get preferred title from LIDO if exists
+
+do list(path:filteredDescriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.0.appellationValue, var:el)
+    if all_match('el.pref', 'preferred')
+        if all_match('el._', '.*\S.*')
+            copy_field('el._', "title_display")
+        end
+    end
+end
+
+# If no preferred title exists, try to get any title from LIDO
+
+unless all_match(title_display, '.*\S.*')
+    do list(path:filteredDescriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.0.appellationValue, var:el)
+        if all_match('el._', '.*\S.*')
+            copy_field('el._', "title_display")
+        end
+    end
+end
+
+# If no title exists, use n/a (not available)
+
+unless all_match('title_display', '.*\S.*')
+    add_field('title_display', 'n/a')
+end
+
+
+## Creator
+ 
+set_array(creator)
+set_array(creator_dod)
+set_array(creator_role)
+set_array(creator_display)
+set_array(creator_index)
+
+# Use the event 'production'
+
+unless is_array('filteredDescriptiveMetadata.eventWrap.eventSet')
+    move_field('filteredDescriptiveMetadata.eventWrap.eventSet', tmp)
+    set_array('filteredDescriptiveMetadata.eventWrap.eventSet')
+    move_field(tmp,'filteredDescriptiveMetadata.eventWrap.eventSet.$append')
+end
+
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var:e)
+
+    do list(path:e.event.eventType.term, var:p)
+    
+        if all_match(p._, 'production')
+
+            # Get the name of the creator from LIDO
+
+            do list(path:e.event.eventActor, var:c)
+                set_array(tmp_creator_display)
+                set_array(tmp_creator_index)
+
+                # Use the name as established by the museum for the detail page (preferred name)
+                # Use the alternate name in the search results if exists, else use the preferred name
+                # If no creator name exists, use n/a (not available)
+
+                do list(path:c.actorInRole.actor.nameActorSet.0.appellationValue, var:d)
+                    if all_match('d.pref', 'preferred')
+                        if all_match(d._, '.*\S.*')
+                            copy_field(d._, tmp_creator_display.$append)
+                            copy_field(d._, tmp_creator_index.$append)
+                        else
+                            add_field(creator_display_na, 'n/a')
+                            copy_field(creator_display_na, tmp_creator_display.$append)
+                            copy_field(creator_display_na, tmp_creator_index.$append)
+                            remove_field(creator_display_na)
+                        end
+                    end
+                end
+
+                do list(path:c.actorInRole.actor.nameActorSet.0.appellationValue, var:d)
+                    if all_match('d.pref', 'alternate')
+                        if all_match(d._, '.*\S.*')
+                            copy_field(d._, tmp_creator_index.$last)
+                        end
+                    end                
+                end
+
+                # Add VIAF alternate names from CREATORS_UTF8.csv
+
+                # The original LIDO data doesn't contain those. It only contains the
+                # data sanctioned by the institutions, not the actual VIAF data itself.
+
+                copy_field(tmp_creator_display.$last, tmp_creator_concord)
+                downcase(tmp_creator_concord)
+                lookup_in_store(tmp_creator_concord, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
+
+                # We store the VIAF alternate names in creator search field. 
+                # This allows users to search on name variants of the creator.
+                # If no VIAF alternate names are found, use n/a (not available)
+
+                if all_match(tmp_creator_concord.viaf_alternate, '.*\S.*')
+                    copy_field(tmp_creator_concord.viaf_alternate, creator.$append)
+                else
+                    add_field(tmp_creator, 'n/a')
+                    copy_field(tmp_creator, creator.$append)
+                    remove_field(tmp_creator)
+                end
+
+                remove_field(tmp_creator_concord)
+
+                # Add LIDO date of death of the creator
+                # If no date of death exists, use n/a (not available)
+                # We use the date of death later on to establish copyright.
+                # Thererfor we don't need the date of birth of the creator.
+
+                if all_match(c.actorInRole.actor.vitalDatesActor.latestDate._, '.*\S.*')
+                    copy_field(c.actorInRole.actor.vitalDatesActor.latestDate._, creator_dod.$append)
+                else
+                    add_field(tmp_creator_dod, 'n/a')
+                    copy_field(tmp_creator_dod, creator_dod.$append)
+                    remove_field(tmp_creator_dod)
+                end
+
+                # LIDO qualifier (copy after, attributed to ...)
+
+                if all_match('c.actorInRole.attributionQualifierActor.$last._', '.*\S.*')
+                    if all_match('c.actorInRole.attributionQualifierActor.$last._', '.*\S.*')
+                        
+                        # add the attribution to the creator_display and creator_index
+
+                        copy_field(c.actorInRole.attributionQualifierActor.$last._, tmp_creator_display.$prepend)
+                        copy_field(c.actorInRole.attributionQualifierActor.$last._, tmp_creator_index.$prepend)
+
+                        # We use the date of death later on to establish copyright.
+                        #
+                        # In case the work is tentatively "attributed to" an artist, we don't take
+                        # the date of death into account.
+                        #
+                        # Why? Because we can't reliable establish that the work was truly created
+                        # by the attributed artist. i.e. The qualifier "copy after" implies
+                        # that this work was created by someone else. "copy after Anthony van Dyck" 
+                        # might have us erroneously infer that the work was created by Anthony van Dyck
+                        # while it may have actually been created in the 20th century.
+                        #
+                        # Instead we'll check the production date for these works.
+
+                        set_field(check_production_date, 'true')
+
+                    end
+                end
+
+                # Creator role (Publisher, Painter,...)
+                # If no creator role exists, use n/a (not available)
+
+                if all_match('c.actorInRole.roleActor.$last.term.$last._', '.*\S.*')
+                    copy_field(c.actorInRole.roleActor.$last.term.$last._, creator_role.$append)
+                else
+                    add_field(tmp_creator_role, 'n/a')
+                    copy_field(tmp_creator_role, creator_role.$append)
+                    remove_field(tmp_creator_role)
+                end
+
+                # Flatten creator_display & creator_index
+
+                join_field(tmp_creator_display, " ")
+                move_field(tmp_creator_display, creator_display.$append)
+
+                join_field(tmp_creator_index, " ")
+                move_field(tmp_creator_index, creator_index.$append)    
+            end
+
+        end
+
+    end
+
+end
+
+# If the fields for creator are empty, use n/a (not available)
+   
+unless all_match(creator.$first, '.*\S.*')
+    set_field(creator.$first, 'n/a')
+end
+
+unless all_match(creator_dod.$first, '.*\S.*')
+    set_field(creator_dod.$first, 'n/a')
+end
+   
+unless all_match(creator_role.$first, '.*\S.*')
+    set_field(creator_role.$first, 'n/a')
+end
+
+unless all_match(creator_display.$first, '.*\S.*')
+    set_field(creator_display.$first, 'n/a')
+end
+
+unless all_match(creator_index.$first, '.*\S.*')
+    set_field(creator_index.$first, 'n/a')
+end
+
+
+## Production date
+
+set_array(production_date)
+
+# Use the event 'production'
+
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var:e)
+
+    do list(path:e.event.eventType.term, var:p)
+
+        if all_match(p._, 'production')
+
+            # Get production date from LIDO
+            # If no production date exists, use n/a (not available)
+
+            do list(path:e.event.eventDate.displayDate, var:dat)
+                if all_match(dat._, '.*\S.*')
+                    copy_field(dat._, production_date.$append)
+                else
+                    add_field(tmp_production_date, 'n/a')
+                    copy_field(tmp_production_date, production_date.$append)
+                    remove_field(tmp_production_date)
+                end
+            end
+
+        end
+
+    end
+
+end
+
+# If the field for production date is empty, use n/a (not available)
+
+unless all_match(production_date.$first, '.*\S.*')
+    set_field(production_date.$first, 'n/a')
+end
+
+
+## Publish image
+
+# This algorithm establishes wether or not a digital representation
+# may be published based on copyright rules.
+#
+# General rule: date of death artist < current date - 70 years
+# 
+# We check if the LIDO date of death of the longest living contributor to the
+# work is more than 70 years ago.
+#
+# In case the work is tentatively "attributed to" an artist, we check the
+# production date, that is, the most recent asserted date instead.
+# 
+# When asserting copyright via the production date of the work, we use
+# this rule: production date < current date - 150 years.
+#
+# Assuming a max life expectancy of 90 years, we rule out all works 
+# created in the past 150 years (70 after presumable death + 80 years).
+# This would rule out the edge case of a creator who died in his 90's, exactly
+# 70 years ago and made his first known works in his teenage years.
+#
+# The algorithm is a two step process:
+#
+#  1. Clean up the date formatting of fields we're going to check against.
+#     They all need to be of the ISO format YYYY. This requires some regex fu.
+#  2. Check against the dates according to the algorithm.
+#
+# This field is what ultimately determines whether an image can be published
+# or not. The default assumption is 'false'. We need to prove that we are
+# allowed to publish the digital image.
+
+add_field(publish_image, "false")
+
+# This is a 'sentinel' variable. As soon as the copyright has been 
+# determined (true), we bail out of the algorithm.
+
+add_field(determined, "false")
+
+# Step 1: Clean out the date formatting
+
+set_field(production_date_copyright)
+set_array(pretty_dod)
+
+copy_field(filteredDescriptiveMetadata.eventWrap.eventSet.0.event.eventDate, dates)
+
+if all_match(check_production_date, 'true')
+
+    if all_match(dates.date.latestDate._, '.*\S.*')
+        if any_match(dates.date.latestDate._, '(\d\d\d\d)-(\d\d)-(\d\d)')
+            parse_text(dates.date.latestDate._, '(\d\d\d\d)-(\d\d)-(\d\d)')
+            if is_number(dates.date.latestDate._.$first)
+                copy_field(dates.date.latestDate._.$first, production_date_copyright)
+            end
+        else 
+            if any_match(dates.date.latestDate._, '(\d\d\d\d)-(\d\d)')
+                parse_text(dates.date.latestDate._, '(\d\d\d\d)-(\d\d)')
+                if is_number(dates.date.latestDate._.$first)
+                    copy_field(dates.date.latestDate._.$first, production_date_copyright)
+                end
+            else
+                if any_match(dates.date.latestDate._, '(\d\d\d\d)')
+                    if is_number(dates.date.latestDate._)
+                        copy_field(dates.date.latestDate._, production_date_copyright)
+                    end
+                else
+                    set_field(determined, "true")
+                end
+            end
+        end
+    end
+
+else
+
+    do list(path: 'creator_dod', var: 'dod')
+        copy_field(dod, tmp_dod)
+        if any_match(tmp_dod, '(\d\d\d\d)-(\d\d)-(\d\d)')
+            parse_text(tmp_dod, '(\d\d\d\d)-(\d\d)-(\d\d)')
+            if is_number(tmp_dod.$first)
+                copy_field(tmp_dod.$first, pretty_dod.$append)
+            end
+        else
+            if any_match(tmp_dod, '(\d\d\d\d)-(\d\d)')
+                parse_text(tmp_dod, '(\d\d\d\d)-(\d\d)')
+                if is_number(tmp_dod.$first)
+                    copy_field(tmp_dod.$first, pretty_dod.$append)
+                end
+            else
+                if any_match(tmp_dod, '(\d\d\d\d)')
+                    if is_number(tmp_dod)
+                        copy_field(tmp_dod, pretty_dod.$append)
+                    end
+                else
+                    set_field(determined, "true")
+                end
+            end
+        end
+        remove_field(tmp_dod)
+    end
+
+end
+
+# Step 2: Actual determination of the copyright
+
+if all_match(check_production_date, 'true')
+
+    if all_equal(determined, "false")
+        if all_match(production_date_copyright, ".*\S.*")
+            if less_than(production_date_copyright, 1870)
+                set_field(publish_image, "true")
+            end
+            set_field(determined, "true")
+        end
+    end
+
+    remove_field(check_production_date)
+
+else
+
+    if all_equal(determined, "false")
+        sort_field(pretty_dod, numeric: 1)
+        if all_match(pretty_dod.$last, ".*\S.*")
+            if less_than(pretty_dod.$last, 1948)
+                set_field(publish_image, "true")
+            end
+            set_field(determined, "true")
+        end
+    end
+
+end
+
+# Done. Remove fields. We don't need them anymore.
+
+remove_field(creator_dod)
+remove_field(pretty_dod)
+remove_field(production_date_copyright)
+remove_field(dates)
+remove_field(determined)
+
+
+## Period
+
+set_array(period)
+
+# Use the event 'production'
+
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var: e)
+    
+    do list(path:e.event.eventType.term, var:p)
+
+        if all_match(p._, 'production')
+
+            # Get period from LIDO
+            # If no period exists, use n/a (not available)
+
+            do list(path:e.event.periodName, var:per)
+
+                # Use NL field
+
+                if all_match('per.term.*.lang', 'nl')
+                    if all_match('per.term.*._', '.*\S.*')
+                        copy_field('per.term.*._', period.$append)
+                    else
+                        add_field(tmp_period, 'n/a')
+                        copy_field(tmp_period, period.$append)
+                        remove_field(tmp_period)
+                    end
+                end
+            end
+
+        end
+
+    end
+
+end
+
+# If the field for period is empty, use n/a (not available)
+
+unless all_match(period.$first, '.*\S.*')
+    set_field(period.$first, 'n/a')
+end
+
+sort_field(period)
+
+
+## Repository
+
+# Get repository from LIDO if exists (repository = data provider / source of record)
+# If no repository exists, use n/a (not available)
+
+if all_match('filteredAdministrativeMetadata.recordWrap.recordSource.0.legalBodyName.0.appellationValue.0._', '.*\S.*')
+    copy_field('filteredAdministrativeMetadata.recordWrap.recordSource.0.legalBodyName.0.appellationValue.0._', 'repository')
+else
+    add_field('repository', 'n/a')
+end
+
+
+## Material
+
+set_array(material_display)
+set_array(material)
+
+# Use the event 'production'
+
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var:e)
+    
+    do list(path:e.event.eventType.term, var:p)
+
+        if all_match(p._, 'production')
+
+            # Get materials from LIDO           
+
+            do list(path:e.event.eventMaterialsTech, var:mat)
+
+                # Use the preferred term for the detail page
+                # Use the alternate term in the search results / facet if exists, else use the preferred term
+                # If no material exists, use n/a (not available)
+
+                if all_match(mat.materialsTech.termMaterialsTech.0.type, 'material')
+
+                    do list(path: 'mat.materialsTech.termMaterialsTech.0.term', var:prefMaterial)
+                        if all_match('prefMaterial.pref', 'preferred')
+                            if all_match(prefMaterial._, '.*\S.*')
+                                copy_field(prefMaterial._, material_display.$append)
+                                copy_field(prefMaterial._, material.$append)
+                            else
+                                add_field(tmp_material, 'n/a')
+                                copy_field(tmp_material, material_display.$append)
+                                copy_field(tmp_material, material.$append)
+                                remove_field(tmp_material)
+                            end
+                        end
+                    end
+
+                    do list(path: 'mat.materialsTech.termMaterialsTech.0.term', var:prefMaterial)
+                        if all_match('prefMaterial.pref', 'alternate')
+                            if all_match(prefMaterial._, '.*\S.*')
+                                copy_field(prefMaterial._, material.$last)
+                            end
+                        end
+                    end
+
+                end
+
+            end
+
+        end
+
+    end
+
+end
+
+# If the fields for material are empty, use n/a (not available)
+
+unless all_match(material_display.$first, '.*\S.*')
+    set_field(material_display.$first, 'n/a')
+end
+
+unless all_match(material.$first, '.*\S.*')
+    set_field(material.$first, 'n/a')
+end
+
+
+## Dimensions
+
+set_array(dimensions)
+
+# Use extent 'geheel'
+
+do list(path:filteredDescriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet, var:el2)
+
+    if all_match(el2.objectMeasurements.extentMeasurements.0._, 'geheel')
+
+        # Get measurements from LIDO
+        # If no measurement exist, use n/a (not available)
+
+        do list(path:el2.objectMeasurements.measurementsSet, var:el)
+            if all_match('el.measurementType.0._', 'hoogte')
+                if all_match(el.measurementValue._, '.*\S.*')
+                    copy_field(el.measurementValue._, dimensionsh.$append)
+                else
+                    add_field(tmp_dimensionsh, 'n/a')
+                    copy_field(tmp_dimensionsh, dimensionsh.$append)
+                    remove_field(tmp_dimensionsh)
+                end
+                if all_match(el.measurementUnit.0._, '.*\S.*')
+                    copy_field(el.measurementUnit.0._, dimensionsh.$append)
+                else
+                    add_field(tmp_dimensionsh, 'n/a')
+                    copy_field(tmp_dimensionsh, dimensionsh.$append)
+                    remove_field(tmp_dimensionsh)
+                end
+                join_field(dimensionsh, ' ')
+                if all_match(dimensionsh, 'n/a n/a')
+                    remove_field(dimensionsh)
+                else
+                    prepend(dimensionsh, 'h ')
+                    move_field(dimensionsh, dimensions.$append)
+                end
+            end
+            if all_match('el.measurementType.0._', 'breedte')
+                if all_match(el.measurementValue._, '.*\S.*')
+                    copy_field(el.measurementValue._, dimensionsw.$append)
+                else
+                    add_field(tmp_dimensionsw, 'n/a')
+                    copy_field(tmp_dimensionsw, dimensionsw.$append)
+                    remove_field(tmp_dimensionsw)                    
+                end
+                if all_match(el.measurementUnit.0._, '.*\S.*')
+                    copy_field(el.measurementUnit.0._, dimensionsw.$append)
+                else
+                    add_field(tmp_dimensionsw, 'n/a')
+                    copy_field(tmp_dimensionsw, dimensionsw.$append)
+                    remove_field(tmp_dimensionsw) 
+                end
+                join_field(dimensionsw, ' ')
+                if all_match(dimensionsw, 'n/a n/a')
+                    remove_field(dimensionsw)
+                else
+                    prepend(dimensionsw, 'b ')
+                    move_field(dimensionsw, dimensions.$append)
+                end
+            end
+            if all_match('el.measurementType.0._', 'diepte')
+                if all_match(el.measurementValue._, '.*\S.*')
+                    copy_field(el.measurementValue._, dimensionsd.$append)
+                else
+                    add_field(tmp_dimensionsd, 'n/a')
+                    copy_field(tmp_dimensionsd, dimensionsd.$append)
+                    remove_field(tmp_dimensionsd)                    
+                end
+                if all_match(el.measurementUnit.0._, '.*\S.*')
+                    copy_field(el.measurementUnit.0._, dimensionsd.$append)
+                else
+                    add_field(tmp_dimensionsd, 'n/a')
+                    copy_field(tmp_dimensionsd, dimensionsd.$append)
+                    remove_field(tmp_dimensionsd) 
+                end
+                join_field(dimensionsd, ' ')
+                if all_match(dimensionsd, 'n/a n/a')
+                    remove_field(dimensionsd)
+                else
+                    prepend(dimensionsd, 'd ')
+                    move_field(dimensionsd, dimensions.$append)
+                end
+            end
+            if all_match('el.measurementType.0._', 'diameter')
+                if all_match(el.measurementValue._, '.*\S.*')
+                    copy_field(el.measurementValue._, dimensionsr.$append)
+                else
+                    add_field(tmp_dimensionsr, 'n/a')
+                    copy_field(tmp_dimensionsr, dimensionsr.$append)
+                    remove_field(tmp_dimensionsr) 
+                end
+                if all_match(el.measurementUnit.0._, '.*\S.*')
+                    copy_field(el.measurementUnit.0._, dimensionsr.$append)
+                else
+                    add_field(tmp_dimensionsr, 'n/a')
+                    copy_field(tmp_dimensionsr, dimensionsr.$append)
+                    remove_field(tmp_dimensionsr) 
+                end
+                join_field(dimensionsr, ' ')
+                if all_match(dimensionsr, 'n/a n/a')
+                    remove_field(dimensionsr)
+                else
+                    append(dimensionsr, ' (diameter)')
+                    move_field(dimensionsr, dimensions.$append)
+                end
+            end
+
+        end
+
+    end
+
+end
+
+# If the field for dimensions is empty, use n/a (not available)
+
+unless all_match(dimensions.$first, '.*\S.*')
+    set_field(dimensions.$first, 'n/a')
+end
+
+
+## Category
+
+set_array(artwork_category_display)
+set_array(artwork_category)
+
+# Use type 'content-motif-general'
+
+do list(path: 'filteredDescriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet', var:c)
+    
+    if all_match(c.subject.type, 'content-motif-general')
+
+        # Get content motif general from LIDO
+        # Use the preferred term for the detail page
+        # Use the alternate term in the search results / facet if exists, else use the preferred term
+        # If no content motif general exists, use n/a (not available)
+
+        do list(path: 'c.subject.subjectConcept.term', var:subject)
+            if all_match('subject.pref', 'preferred')
+                if all_match(subject._, '.*\S.*')
+                    copy_field(subject._, artwork_category_display.$append)
+                    copy_field(subject._, artwork_category.$append)
+                else
+                    add_field(tmp_artwork_category_display, 'n/a')
+                    copy_field(tmp_artwork_category_display, artwork_category_display.$append)
+                    copy_field(tmp_artwork_category_display, artwork_category.$append)
+                    remove_field(tmp_artwork_category_display)
+                end
+            end
+        end
+
+        do list(path: 'c.subject.subjectConcept.term', var:subject)
+            if all_match('subject.pref', 'alternate')
+                if all_match(subject._, '.*\S.*')
+                    copy_field(subject._, artwork_category.$last)
+                end
+            end
+        end
+
+    end
+
+end
+
+# If the fields for artwork category are empty, use n/a (not available)
+
+unless all_match(artwork_category_display.$first, '.*\S.*')
+    set_field(artwork_category_display.$first, 'n/a')
+end
+
+unless all_match(artwork_category.$first, '.*\S.*')
+    set_field(artwork_category.$first, 'n/a')
+end
+
+
+## Artwork_type
+
+set_array(artwork_type_display)
+set_array(artwork_type)
+
+# Use type 'object-category'
+
+do list(path: 'filteredDescriptiveMetadata.objectClassificationWrap.classificationWrap.classification', var:c)
+    
+    if all_match(c.type, 'object-category')
+        
+        # Get artwork type from LIDO
+        # Use the preferred term for the detail page
+        # Use the alternate term in the search results / facet if exists, else use the preferred term
+        # If no artwork type exists, use n/a (not available)
+
+        do list(path: 'c.term', var:classification)
+            if all_match('classification.pref', 'preferred')
+                if all_match(classification._, '.*\S.*')
+                    copy_field(classification._, artwork_type_display.$append)
+                    copy_field(classification._, artwork_type.$append)
+                else
+                    add_field(tmp_artwork_type_display, 'n/a')
+                    copy_field(tmp_artwork_type_display, artwork_type_display.$append)
+                    copy_field(tmp_artwork_type_display, artwork_type.$append)
+                    remove_field(tmp_artwork_type_display)
+                end
+            end
+        end
+
+        do list(path: 'c.term', var:classification)
+            if all_match('classification.pref', 'alternate')
+                if all_match(classification._, '.*\S.*')
+                    copy_field(classification._, artwork_type.$last)
+                end
+            end
+        end
+
+    end
+
+end
+
+# If the fields for artwork type are empty, use n/a (not available)
+
+unless all_match(artwork_type_display.$first, '.*\S.*')
+    set_field(artwork_type_display.$first, 'n/a')
+end
+
+unless all_match(artwork_type.$first, '.*\S.*')
+    set_field(artwork_type.$first, 'n/a')
+end
+
+
+## Artwork_subtype
+
+set_array(artwork_subtype_display)
+set_array(artwork_subtype)
+
+# Get artwork subtype from LIDO
+# Use the preferred term for the detail page
+# Use the alternate term in the search results / facet if exists, else use the preferred term
+# If no artwork subtype exists, use n/a (not available)
+
+do list(path: 'filteredDescriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType', var:t)
+    
+    do list(path: 't.term', var:type)
+        if all_match('type.pref', 'preferred')
+            if all_match(type._, '.*\S.*')
+                copy_field(type._, artwork_subtype_display.$append)
+                copy_field(type._, artwork_subtype.$append)
+            else
+                add_field(tmp_artwork_subtype_display, 'n/a')
+                copy_field(tmp_artwork_subtype_display, artwork_subtype_display.$append)
+                copy_field(tmp_artwork_subtype_display, artwork_subtype.$append)
+                remove_field(tmp_artwork_subtype_display)
+            end
+        end
+    end
+
+    do list(path: 't.term', var:type)
+        if all_match('type.pref', 'alternate')
+            if all_match(type._, '.*\S.*')
+                copy_field(type._, artwork_subtype.$last)
+            end
+        end
+    end
+
+end
+
+# If the fields for artwork subtype are empty, use n/a (not available)
+
+unless all_match(artwork_subtype_display.$first, '.*\S.*')
+    set_field(artwork_subtype_display.$first, 'n/a')
+end
+
+unless all_match(artwork_subtype.$first, '.*\S.*')
+    set_field(artwork_subtype.$first, 'n/a')
+end
+
+
+## Object_number
+
+if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0.type', 'object-number')
+    if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0._', '.*\S.*')
+        copy_field('filteredDescriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0._', 'object_number')
+    else
+        add_field('object_number', 'n/a')
+    end
+end
+
+unless exists(object_number)
+    add_field(object_number, 'n/a')
+end
+
+
+## Description
+
+if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', '.*\S.*')
+    if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', '.*\S.*')
+        copy_field('filteredDescriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', 'description')
+    else
+        add_field('description', 'n/a')
+    end
+end
+
+unless exists(description)
+    add_field(description, 'n/a')
+end
+
+
+## Work_pid
+
+if all_match('_metadata.objectPublishedID.0._', '.*\S.*')
+    copy_field('_metadata.objectPublishedID.0._', 'work_pid')
+else
+    add_field('work_pid', 'n/a')
+end
+
+unless exists(work_pid)
+    add_field(work_pid, 'n/a')
+end
+
+
+## Data_pid
+
+do list(path: '_metadata.lidoRecID', var:lidoRecID)
+    if all_match('lidoRecID.type', 'purl')
+        if all_match(lidoRecID._, '.*\S.*')
+            copy_field(lidoRecID._, data_pid)
+        else
+            add_field(data_pid, 'n/a')
+        end
+    end
+
+    # The field 'raw' is used in process.pl to map the entire LIDO XML to a Solr field called 'xml' and is removed there at the end
+    # See: https://github.com/VlaamseKunstcollectie/Datahub-Fixes/blob/master/scripts/process.pl
+
+    if all_match('lidoRecID.type', 'urn')
+        copy_field(lidoRecID._, raw)
+    end
+end
+
+unless exists(data_pid)
+    add_field(data_pid, 'n/a')
+end
+
+
+## Resource sets
+
+unless is_array('filteredAdministrativeMetadata.resourceWrap.resourceSet')
+    move_field('filteredAdministrativeMetadata.resourceWrap.resourceSet', tmp)
+    set_array('filteredAdministrativeMetadata.resourceWrap.resourceSet')
+    move_field(tmp,'filteredAdministrativeMetadata.resourceWrap.resourceSet.$append')
+end
+
+
+## Representation_pid
+
+do list(path:'filteredAdministrativeMetadata.resourceWrap.resourceSet', var:r)
+    if all_match('r.resourceID.label', 'representationPID')
+        if all_match('r.resourceID._', '.*\S.*')
+            copy_field('r.resourceID._', 'representation_pid')
+        end
+    end
+end
+
+unless exists(representation_pid)
+    add_field(representation_pid, 'n/a')
+end
+
+
+## Manifest_url
+
+#do list(path:'filteredAdministrativeMetadata.resourceWrap.resourceSet', var:r)
+    
+#    do list(path:'r.resourceType.term', var:m)
+#        if all_match(m._, 'IIIF Manifest')
+#            if all_match('r.resourceID._', '.*\S.*')
+#                copy_field('r.resourceID._', 'manifest_url')
+#            end
+#        end
+#    end
+
+#end
+
+#unless exists(manifest_url)
+#    add_field(manifest_url, 'n/a')
+#end
+
+
+## Thumbnail_url
+
+#do list(path:'filteredAdministrativeMetadata.resourceWrap.resourceSet', var:r)
+    
+#    do list(path:'r.resourceType.term', var:t)
+#        if all_match(t._, 'thumbnail')
+#            if all_match('r.resourceID._', '.*\S.*')
+#                copy_field('r.resourceID._', 'thumbnail_url')
+#            end
+#        end
+#    end
+
+#end
+
+#unless exists(thumbnail_url)
+#    add_field(thumbnail_url, 'n/a')
+#end
+
+
+## Language
+
+add_field('language', 'English')
+
+## ID
+
+# The ID in Solr is based on the data_pid. The data_pid is converted to a string
+# which can be safely used as an identifier in Project Blacklight. The format of
+# the ID field looks like this:
+#
+#   <domain>:<identifier>
+#   ex. kmksa:254
+#   ex. collectievlaamsegemeenschap:837
+#
+# Note: the .tld is stripped from the domainname because the . (dot) breaks the
+# route matching algoritm.
+
+unless all_match(data_pid, 'n/a')
+    copy_field('data_pid', 'id')
+    parse_text('id', '.*://([A-Za-z0-9\-\.]+)/collection/work/data/(.*)')
+    replace_all('id.0', '([^.]*)\.[^.]{2,3}(?:\.[^.]{2,3})?$', '$1')
+    join_field(id, ':')
+    prepend('id', 'en:')
+end
+
+unless exists(id)
+    add_field(id, 'n/a')
+end
+
+
+# Retain only those records that have a workPid
+unless all_match('work_pid', 'http://*')
+    reject()
+end
+
+# Remove all original fields and only retain the ones we set
+remove_field('_id')
+remove_field('_identifier')
+remove_field('_status')
+remove_field('_setSpec')
+remove_field('_about')
+remove_field('_datestamp')
+remove_field('_metadata')
+remove_field('_resumption')
+remove_field('_resumptionToken')
+
+# Remove the fields that filter on language
+remove_field('filteredDescriptiveMetadata')
+remove_field('filteredAdministrativeMetadata')

--- a/datahub-oai-to-blacklight-solr-nl.fix
+++ b/datahub-oai-to-blacklight-solr-nl.fix
@@ -49,23 +49,20 @@
 #       pref: preferred                             artwork_subtype_display
 #       pref: alternate                             artwork_subtype
 # lido:classification
-#   type: objectcategorie
+#   type: object-category
 #       lido:term
 #           pref: preferred                         artwork_type_display
 #           pref: alternate                         artwork_type  
-#   type: hoofdmotief
-#       lido:term
-#           pref: preferred                         artwork_category_display
-#           pref: alternate                         artwork_category  
 # lido:titleSet                                     
 #   pref: preferred                                 title_display
 # lido:workID
-#   type: objectnummer                              object_number
+#   type: object-number                             object_number
 # lido:objectDescriptionSet                         description
 # lido:objectMeasurementsSet
 #   lido:measurementsSet
 #       lido:extentMeasurements
 #           geheel                                  dimensions
+#
 #                                                   creator
 # lido:eventType
 #   lido:term
@@ -82,22 +79,65 @@
 #               lido:term
 #                   lang: nl                        period
 #           lido:termMaterialsTech
+#               type: material
+#                   lido:term
+#                       pref: preferred             material_display
+#                       pref: alternate             material
+# lido:objectRelationWrap
+#   lido:subject
+#       type: content-motif-general
+#           lido:subjectConcept
 #               lido:term
-#                   pref: alternate                 material
-#           lido:displayMaterialsTech               material_display
+#                   pref: preferred                 artwork_category_display
+#                   pref: alternate                 artwork_category
 # lido:recordWrap          
 #   lido:recordSource
 #       lido:legalBodyName                          repository
 # lido:resourceWrap
-#   lido:resourceID                                 representation_pid
+#   lido:resourceSet
+#       lido:resourceID                             representation_pid
+#       lido:resourceRepresentation
+#   lido:resourceSet
+#       lido:resourceID                             manifest_url
+#       lido:resourceType
+#           lido:term
+#               IIIF Manifest
+#   lido:resourceSet
+#       lido:resourceID                             thumbnail_url
+#       lido:resourceType
+#           lido:term
+#               thumbnail
+#
 #                                                   publish_image          
+
+
+## DescriptiveMetadata
+
+# Copy field to filter on language
+
+do list(path:_metadata.descriptiveMetadata, var:dm)
+    if all_match('dm.lang', 'nl')
+        copy_field('dm', 'filteredDescriptiveMetadata')
+    end
+end
+
+
+## AdministrativeMetadata
+
+# Copy field to filter on language
+
+do list(path:_metadata.administrativeMetadata, var:am)
+    if all_match('am.lang', 'nl')
+        copy_field('am', 'filteredAdministrativeMetadata')
+    end
+end
 
 
 ## Title
 
 # Get preferred title from LIDO if exists
 
-do list(path:_metadata.descriptiveMetadata.0.objectIdentificationWrap.titleWrap.titleSet.0.appellationValue, var:el)
+do list(path:filteredDescriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.0.appellationValue, var:el)
     if all_match('el.pref', 'preferred')
         if all_match('el._', '.*\S.*')
             copy_field('el._', "title_display")
@@ -108,7 +148,7 @@ end
 # If no preferred title exists, try to get any title from LIDO
 
 unless all_match(title_display, '.*\S.*')
-    do list(path:_metadata.descriptiveMetadata.0.objectIdentificationWrap.titleWrap.titleSet.0.appellationValue, var:el)
+    do list(path:filteredDescriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.0.appellationValue, var:el)
         if all_match('el._', '.*\S.*')
             copy_field('el._', "title_display")
         end
@@ -132,13 +172,13 @@ set_array(creator_index)
 
 # Use the event 'production'
 
-unless is_array('_metadata.descriptiveMetadata.0.eventWrap.eventSet')
-    move_field('_metadata.descriptiveMetadata.0.eventWrap.eventSet', tmp)
-    set_array('_metadata.descriptiveMetadata.0.eventWrap.eventSet')
-    move_field(tmp,'_metadata.descriptiveMetadata.0.eventWrap.eventSet.$append')
+unless is_array('filteredDescriptiveMetadata.eventWrap.eventSet')
+    move_field('filteredDescriptiveMetadata.eventWrap.eventSet', tmp)
+    set_array('filteredDescriptiveMetadata.eventWrap.eventSet')
+    move_field(tmp,'filteredDescriptiveMetadata.eventWrap.eventSet.$append')
 end
 
-do list(path:'_metadata.descriptiveMetadata.0.eventWrap.eventSet', var:e)
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var:e)
 
     do list(path:e.event.eventType.term, var:p)
     
@@ -295,7 +335,7 @@ set_array(production_date)
 
 # Use the event 'production'
 
-do list(path:'_metadata.descriptiveMetadata.0.eventWrap.eventSet', var:e)
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var:e)
 
     do list(path:e.event.eventType.term, var:p)
 
@@ -370,7 +410,7 @@ add_field(determined, "false")
 set_field(production_date_copyright)
 set_array(pretty_dod)
 
-copy_field(_metadata.descriptiveMetadata.0.eventWrap.eventSet.0.event.eventDate, dates)
+copy_field(filteredDescriptiveMetadata.eventWrap.eventSet.0.event.eventDate, dates)
 
 if all_match(check_production_date, 'true')
 
@@ -472,7 +512,7 @@ set_array(period)
 
 # Use the event 'production'
 
-do list(path:'_metadata.descriptiveMetadata.0.eventWrap.eventSet', var: e)
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var: e)
     
     do list(path:e.event.eventType.term, var:p)
 
@@ -516,8 +556,8 @@ sort_field(period)
 # Get repository from LIDO if exists (repository = data provider / source of record)
 # If no repository exists, use n/a (not available)
 
-if all_match('_metadata.administrativeMetadata.0.recordWrap.recordSource.0.legalBodyName.0.appellationValue.0._', '.*\S.*')
-    copy_field('_metadata.administrativeMetadata.0.recordWrap.recordSource.0.legalBodyName.0.appellationValue.0._', 'repository')
+if all_match('filteredAdministrativeMetadata.recordWrap.recordSource.0.legalBodyName.0.appellationValue.0._', '.*\S.*')
+    copy_field('filteredAdministrativeMetadata.recordWrap.recordSource.0.legalBodyName.0.appellationValue.0._', 'repository')
 else
     add_field('repository', 'n/a')
 end
@@ -530,7 +570,7 @@ set_array(material)
 
 # Use the event 'production'
 
-do list(path:'_metadata.descriptiveMetadata.0.eventWrap.eventSet', var:e)
+do list(path:'filteredDescriptiveMetadata.eventWrap.eventSet', var:e)
     
     do list(path:e.event.eventType.term, var:p)
 
@@ -540,53 +580,34 @@ do list(path:'_metadata.descriptiveMetadata.0.eventWrap.eventSet', var:e)
 
             do list(path:e.event.eventMaterialsTech, var:mat)
 
-                # Use the physical description for the detail page if exists, els use the preferred term
+                # Use the preferred term for the detail page
                 # Use the alternate term in the search results / facet if exists, else use the preferred term
                 # If no material exists, use n/a (not available)
 
-                do list(path: 'mat.materialsTech.termMaterialsTech.0.term', var:prefMaterial)
-                    if all_match('prefMaterial.pref', 'preferred')
-                        if all_match(prefMaterial._, '.*\S.*')
-                            copy_field(prefMaterial._, material_display.$append)
-                            copy_field(prefMaterial._, material.$append)
-                        else
-                            add_field(tmp_material, 'n/a')
-                            copy_field(tmp_material, material_display.$append)
-                            copy_field(tmp_material, material.$append)
-                            remove_field(tmp_material)
+                if all_match(mat.materialsTech.termMaterialsTech.0.type, 'material')
+
+                    do list(path: 'mat.materialsTech.termMaterialsTech.0.term', var:prefMaterial)
+                        if all_match('prefMaterial.pref', 'preferred')
+                            if all_match(prefMaterial._, '.*\S.*')
+                                copy_field(prefMaterial._, material_display.$append)
+                                copy_field(prefMaterial._, material.$append)
+                            else
+                                add_field(tmp_material, 'n/a')
+                                copy_field(tmp_material, material_display.$append)
+                                copy_field(tmp_material, material.$append)
+                                remove_field(tmp_material)
+                            end
                         end
                     end
-                end
 
-                do list(path: 'mat.materialsTech.termMaterialsTech.0.term', var:prefMaterial)
-                    if all_match('prefMaterial.pref', 'alternate')
-                        if all_match(prefMaterial._, '.*\S.*')
-                            copy_field(prefMaterial._, material.$last)
+                    do list(path: 'mat.materialsTech.termMaterialsTech.0.term', var:prefMaterial)
+                        if all_match('prefMaterial.pref', 'alternate')
+                            if all_match(prefMaterial._, '.*\S.*')
+                                copy_field(prefMaterial._, material.$last)
+                            end
                         end
                     end
-                end
 
-            end
-
-        end
-
-    end
-
-end
-
-do list(path:'_metadata.descriptiveMetadata.0.eventWrap.eventSet', var:e)
-
-    do list(path:e.event.eventType.term, var:p)
-
-        if all_match(p._, 'production')
-
-            do list(path:e.event.eventMaterialsTech, var:mat)
-
-                do list(path: 'mat.displayMaterialsTech', var:displayMaterial)
-                    if all_match('displayMaterial._', '.*\S.*')
-                        remove_field(material_display)
-                        copy_field(displayMaterial._, material_display.$append)
-                    end
                 end
 
             end
@@ -612,9 +633,9 @@ end
 
 set_array(dimensions)
 
-# Use extent 'geheel' (used in AdLib) or 'Volledig' (used in TMS)
+# Use extent 'geheel'
 
-do list(path:_metadata.descriptiveMetadata.0.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet, var:el2)
+do list(path:filteredDescriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet, var:el2)
 
     if all_match(el2.objectMeasurements.extentMeasurements.0._, 'geheel')
 
@@ -717,24 +738,6 @@ do list(path:_metadata.descriptiveMetadata.0.objectIdentificationWrap.objectMeas
 
         end
 
-    else
-
-        if all_match(el2.objectMeasurements.extentMeasurements.0._, 'Volledig')
-
-            if all_match(el2.displayObjectMeasurements.0._, '.*\S.*')
-
-                if all_match(dimensions.$first, '.*\S.*')
-                    unless in(el2.displayObjectMeasurements.0._, dimensions.$last)
-                        copy_field(el2.displayObjectMeasurements.0._, dimensions.$append)
-                    end
-                else
-                    copy_field(el2.displayObjectMeasurements.0._, dimensions.$append)
-                end
-
-            end
-
-        end
-
     end
 
 end
@@ -751,22 +754,22 @@ end
 set_array(artwork_category_display)
 set_array(artwork_category)
 
-# Use type 'hoofdmotief'
+# Use type 'content-motif-general'
 
-do list(path: '_metadata.descriptiveMetadata.0.objectClassificationWrap.classificationWrap.classification', var:c)
+do list(path: 'filteredDescriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet', var:c)
     
-    if all_match(c.type, 'hoofdmotief')
+    if all_match(c.subject.type, 'content-motif-general')
 
-        # Get artwork category from LIDO
+        # Get content motif general from LIDO
         # Use the preferred term for the detail page
         # Use the alternate term in the search results / facet if exists, else use the preferred term
-        # If no artwork category exists, use n/a (not available)
+        # If no content motif general exists, use n/a (not available)
 
-        do list(path: 'c.term', var:classification)
-            if all_match('classification.pref', 'preferred')
-                if all_match(classification._, '.*\S.*')
-                    copy_field(classification._, artwork_category_display.$append)
-                    copy_field(classification._, artwork_category.$append)
+        do list(path: 'c.subject.subjectConcept.term', var:subject)
+            if all_match('subject.pref', 'preferred')
+                if all_match(subject._, '.*\S.*')
+                    copy_field(subject._, artwork_category_display.$append)
+                    copy_field(subject._, artwork_category.$append)
                 else
                     add_field(tmp_artwork_category_display, 'n/a')
                     copy_field(tmp_artwork_category_display, artwork_category_display.$append)
@@ -776,10 +779,10 @@ do list(path: '_metadata.descriptiveMetadata.0.objectClassificationWrap.classifi
             end
         end
 
-        do list(path: 'c.term', var:classification)
-            if all_match('classification.pref', 'alternate')
-                if all_match(classification._, '.*\S.*')
-                    copy_field(classification._, artwork_category.$last)
+        do list(path: 'c.subject.subjectConcept.term', var:subject)
+            if all_match('subject.pref', 'alternate')
+                if all_match(subject._, '.*\S.*')
+                    copy_field(subject._, artwork_category.$last)
                 end
             end
         end
@@ -804,11 +807,11 @@ end
 set_array(artwork_type_display)
 set_array(artwork_type)
 
-# Use type 'objectcategorie'
+# Use type 'object-category'
 
-do list(path: '_metadata.descriptiveMetadata.0.objectClassificationWrap.classificationWrap.classification', var:c)
+do list(path: 'filteredDescriptiveMetadata.objectClassificationWrap.classificationWrap.classification', var:c)
     
-    if all_match(c.type, 'objectcategorie')
+    if all_match(c.type, 'object-category')
         
         # Get artwork type from LIDO
         # Use the preferred term for the detail page
@@ -862,7 +865,7 @@ set_array(artwork_subtype)
 # Use the alternate term in the search results / facet if exists, else use the preferred term
 # If no artwork subtype exists, use n/a (not available)
 
-do list(path: '_metadata.descriptiveMetadata.0.objectClassificationWrap.objectWorkTypeWrap.objectWorkType', var:t)
+do list(path: 'filteredDescriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType', var:t)
     
     do list(path: 't.term', var:type)
         if all_match('type.pref', 'preferred')
@@ -901,9 +904,9 @@ end
 
 ## Object_number
 
-if all_match('_metadata.descriptiveMetadata.0.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0.type', 'objectnummer')
-    if all_match('_metadata.descriptiveMetadata.0.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0._', '.*\S.*')
-        copy_field('_metadata.descriptiveMetadata.0.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0._', 'object_number')
+if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0.type', 'object-number')
+    if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0._', '.*\S.*')
+        copy_field('filteredDescriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.0.workID.0._', 'object_number')
     else
         add_field('object_number', 'n/a')
     end
@@ -916,10 +919,12 @@ end
 
 ## Description
 
-if all_match('_metadata.descriptiveMetadata.0.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', '.*\S.*')
-    copy_field('_metadata.descriptiveMetadata.0.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', 'description')
-else
-    add_field('description', 'n/a')
+if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', '.*\S.*')
+    if all_match('filteredDescriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', '.*\S.*')
+        copy_field('filteredDescriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.0.descriptiveNoteValue.0._', 'description')
+    else
+        add_field('description', 'n/a')
+    end
 end
 
 unless exists(description)
@@ -964,18 +969,71 @@ unless exists(data_pid)
 end
 
 
+## Resource sets
+
+unless is_array('filteredAdministrativeMetadata.resourceWrap.resourceSet')
+    move_field('filteredAdministrativeMetadata.resourceWrap.resourceSet', tmp)
+    set_array('filteredAdministrativeMetadata.resourceWrap.resourceSet')
+    move_field(tmp,'filteredAdministrativeMetadata.resourceWrap.resourceSet.$append')
+end
+
+
 ## Representation_pid
 
-if all_match('_metadata.administrativeMetadata.0.resourceWrap.resourceSet.resourceID', '.*\S.*')
-    copy_field('_metadata.administrativeMetadata.0.resourceWrap.resourceSet.resourceID', 'representation_pid')
-else
-    add_field('representation_pid', 'n/a')
+do list(path:'filteredAdministrativeMetadata.resourceWrap.resourceSet', var:r)
+    if all_match('r.resourceID.label', 'representationPID')
+        if all_match('r.resourceID._', '.*\S.*')
+            copy_field('r.resourceID._', 'representation_pid')
+        end
+    end
 end
 
 unless exists(representation_pid)
     add_field(representation_pid, 'n/a')
 end
 
+
+## Manifest_url
+
+#do list(path:'filteredAdministrativeMetadata.resourceWrap.resourceSet', var:r)
+    
+#    do list(path:'r.resourceType.term', var:m)
+#        if all_match(m._, 'IIIF Manifest')
+#            if all_match('r.resourceID._', '.*\S.*')
+#                copy_field('r.resourceID._', 'manifest_url')
+#            end
+#        end
+#    end
+
+#end
+
+#unless exists(manifest_url)
+#    add_field(manifest_url, 'n/a')
+#end
+
+
+## Thumbnail_url
+
+#do list(path:'filteredAdministrativeMetadata.resourceWrap.resourceSet', var:r)
+    
+#    do list(path:'r.resourceType.term', var:t)
+#        if all_match(t._, 'thumbnail')
+#            if all_match('r.resourceID._', '.*\S.*')
+#                copy_field('r.resourceID._', 'thumbnail_url')
+#            end
+#        end
+#    end
+
+#end
+
+#unless exists(thumbnail_url)
+#    add_field(thumbnail_url, 'n/a')
+#end
+
+
+## Language
+
+add_field('language', 'Dutch')
 
 ## ID
 
@@ -995,6 +1053,7 @@ unless all_match(data_pid, 'n/a')
     parse_text('id', '.*://([A-Za-z0-9\-\.]+)/collection/work/data/(.*)')
     replace_all('id.0', '([^.]*)\.[^.]{2,3}(?:\.[^.]{2,3})?$', '$1')
     join_field(id, ':')
+    prepend('id', 'nl:')
 end
 
 unless exists(id)
@@ -1017,3 +1076,7 @@ remove_field('_datestamp')
 remove_field('_metadata')
 remove_field('_resumption')
 remove_field('_resumptionToken')
+
+# Remove the fields that filter on language
+remove_field('filteredDescriptiveMetadata')
+remove_field('filteredAdministrativeMetadata')

--- a/groeninge_oai_adlib.fix
+++ b/groeninge_oai_adlib.fix
@@ -15,26 +15,26 @@
     copy_field(_metadata.Object_name, or_record.object_name)
     copy_field(_metadata.object_category, or_record.object_category)
     copy_field('_metadata.object_category\.lref', or_record.object_category_id)
-    copy_field('_metadata.content\.motif\.general', or_record.subject)
-    copy_field('_metadata.content\.motif\.general\.lref', or_record.subject_id)
     copy_field(_metadata.Title, or_record.title)
     copy_field(_metadata.Titel_translation, or_record.title_translation)
     copy_field('_metadata.institution\.name', or_record.institution)
     copy_field(_metadata.object_number, or_record.object_number)
     copy_field(_metadata.Description, or_record.description)
     copy_field(_metadata.Dimension, or_record.dimensions)
+#    copy_field(_metadata.Acquisition_source, or_record.acquisition_source)
+#    copy_field('_metadata.acquisition\.date', or_record.acquisition_date)
 #    copy_field('_metadata.acquisition\.method', or_record.acquisition_method)
 #    copy_field('_metadata.acquisition\.method\.lref', or_record.acquisition_method_id)
-#    copy_field('_metadata.Acquisition_source.acquisition\.source.value', or_record.acquisition_source)
-#    copy_field('_metadata.acquisition\.date', or_record.acquisition_date)
     copy_field(_metadata.Production, or_record.production)
     copy_field(_metadata.Production_date, or_record.production_date)
     copy_field('_metadata.production\.period', or_record.production_period)
     copy_field('_metadata.production\.period\.lref', or_record.production_period_id)
     copy_field(_metadata.Material, or_record.materials)
     copy_field(_metadata.physical_description, or_record.physical_description)
-    copy_field(_metadata.Content_person, or_record.depicted_person)
+    copy_field('_metadata.content\.motif\.general', or_record.content_motif_general)
+    copy_field('_metadata.content\.motif\.general\.lref', or_record.content_motif_general_id)
     copy_field(_metadata.Content_subject, or_record.depicted_subject)
+    copy_field(_metadata.Content_person, or_record.depicted_person)
     copy_field(_metadata.priref, or_record.priref)
 
 # Remove all Adlib fields, retaining only the fields to create the lido structure
@@ -61,36 +61,33 @@
 #   Object_name.object_name                                     pref: preferred                             Subtype                 term objectnaam
 #                                                               pref: alternate                             Subtype
 #                                                       lido:classification
-#                                                           type: objectcategorie
+#                                                           type: object-category
 #                                                               lido:conceptID
 #   object_category.\lref                                           pref: preferred
 #                                                                   pref: alternate                                                 identificatie
 #                                                               lido:term
 #   object_category                                                 pref: preferred                         Type                    term
 #                                                                   pref: alternate                         Type
-#                                                           type: hoofdmotief
-#                                                               lido:conceptID
-#   content\.motif\.general\.lref                                   pref: preferred
-#                                                                   pref: alternate                                                 identificatie hoofdmotief
-#                                                               lido:term
-#   content\.motif\.general                                         pref: preferred                         Onderwerp               term hoofdmotief
-#                                                                   pref: alternate                         Onderwerp
 #                                                       lido:titleSet
 #   Title                                                   pref: preferred                                                         titel
 #   Titel_translation                                       pref: alternate
-#   institution\.name.value                             lido:repositoryName                                 Instelling              naam bewaarinstelling
-#                                                       lido:workID
-#   object_number                                           type: objectnummer                              Inventarisnummer        waarde objectnummer
+#                                                       lido:repositorySet
+#   institution\.name                                       lido:repositoryName                             Instelling              naam bewaarinstelling
+#                                                           lido:workID
+#   object_number                                               type: object-number                         Inventarisnummer        waarde objectnummer
 #   Description                                         lido:objectDescriptionSet                           Beschrijving            korte beschrijving
 #                                                       lido:objectMeasurementsSet
 #                                                           lido:measurementsSet
-#   Dimension.dimension\.type.value                             lido:measurementType                        Dimensies               dimensie afmeting
-#   Dimension.dimension\.unit.value                             lido:measurementUnit                        Dimensies               eenheid afmeting
+#   Dimension.dimension\.type                                   lido:measurementType                                                dimensie afmeting
+#   Dimension.dimension\.unit                                   lido:measurementUnit                        Dimensies               eenheid afmeting
 #   Dimension.dimension\.value                                  lido:measurementValue                       Dimensies               waarde afmeting
 #   Dimension.dimension\.part                               lido:extentMeasurements                                                 onderdeel afmeting
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               acquisition
+#   Acquisition_source.acquisition\.source                          lido:eventActor                                                 naam verwervingsbron
+#                                                                   lido:eventDate
+#   acquisition\.date                                                   lido:displayDate                                            waarde verwervingdatum
 #                                                                   lido:eventMethod
 #                                                                       lido:conceptID
 #   acquisition\.method\.lref                                               pref: preferred
@@ -98,10 +95,6 @@
 #                                                                       lido:term
 #   acquisition\.method                                                     pref: preferred                                         term verwervingsmethode
 #                                                                           pref: alternate
-#                                                                   lido:eventActor
-#   Acquisition_source                                                  lido:nameActorSet                                           naam verwervingsbron
-#                                                                   lido:eventDate
-#   acquisition\.date                                                   lido:displayDate                                            waarde verwervingdatum
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               production
@@ -109,13 +102,13 @@
 #                                                                       lido:actorID
 #   Production.creator\.lref                                                type: local
 #                                                                           type: purl                                              identificatie vervaardiger
-#   Production.creator.value                                            lido:nameActorSet
+#   Production.creator                                                  lido:nameActorSet
 #                                                                           pref: preferred                 Vervaardiger            naam vervaardiger
 #                                                                           pref: alternate
 #                                                                       lido:vitalDatesActor
 #   Production.creator\.date_of_birth                                       lido:earliestDate
 #   Production.creator\.date_of_death                                       lido:latestDate
-#   Production.creator\.role.value                                      lido:roleActor                      Vervaardiger            rol vervaardiger
+#   Production.creator\.role                                            lido:roleActor                      Vervaardiger            rol vervaardiger
 #   Production.creator\.qualifier                                       lido:attributionQualifierActor      Vervaardiger            kwalificatie vervaardiger
 #                                                                   lido:eventDate
 #                                                                       lido:displayDate                    Datering
@@ -130,15 +123,16 @@
 #                                                                       lido:placeID
 #   Production.production\.place\.lref                                      type: local
 #                                                                       lido:namePlaceSet
-#   Production.production\.place.value                                      type: preferred
+#   Production.production\.place                                            type: preferred
 #                                                                   lido:termMaterialsTech
-#                                                                       lido:conceptID
-#   Material.material\.lref                                                 pref: preferred
-#                                                                           pref: alternate                                         identificatie materiaal
-#                                                                       lido:term
-#   Material.material.value                                                 pref: preferred                                         term materiaal
-#                                                                           pref: alternate
-#   physical_description                                            lido:displayMaterialsTech               Materiaal
+#                                                                       type: material
+#                                                                           lido:conceptID
+#   Material.material\.lref                                                     pref: preferred
+#                                                                               pref: alternate                                     identificatie materiaal
+#                                                                           lido:term
+#   Material.material                                                           pref: preferred             Materiaal               term materiaal
+#                                                                               pref: alternate
+#   physical_description                                            lido:displayMaterialsTech
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               check
@@ -147,21 +141,34 @@
 #                                                                       lido:nameActorSet                                           assessor conditie
 #                                                                   lido:eventDate
 #                                                                       lido:displayDate                                            datum conditie
-#                                                       lido:subject
-#                                                           lido:type
-#                                                               lido:subjectConcept
-#   Content_subject.content\.subject\.lref                          lido:conceptID                                                  identificatie afgebeeld concept
-#   Content_subject.content\.subject.value                          lido:term                                                       term afgebeeld concept
-#                                                               lido:subjectPlace
-#   Content_subject.content\.subject\.lref                          lido:placeID                                                    identificatie afgebeelde locatie
-#   Content_subject.content\.subject.value                          lido:namePlaceSet                                               naam afgebeelde locatie
-#                                                               lido:subjectActor
-#   Content_person.content\.person\.name\.lref                      lido:actorID                                                    identificatie afgebeelde persoon of instelling
-#   Content_person.content\.person\.name.value                      lido:nameActorSet                                               naam afgebeelde persoon of instelling
+#                                                       lido:objectRelationWrap
+#                                                           lido:subject
+#                                                               type: content-motif-general
+#                                                                   lido:subjectConcept
+#                                                                       lido:conceptID
+#   content\.motif\.general\.lref                                           pref: preferred
+#                                                                           pref: alternate                                         identificatie hoofdmotief
+#                                                                       lido:term
+#   content\.motif\.general                                                 pref: preferred                 Onderwerp               term hoofdmotief
+#                                                                           pref: alternate                 Onderwerp
+#                                                               no type
+#                                                                   lido:subjectConcept
+#   Content_subject.content\.subject\.lref                              lido:conceptID                                              identificatie afgebeeld concept
+#   Content_subject.content\.subject                                    lido:term                                                   term afgebeeld concept
+#                                                                   lido:subjectActor
+#   Content_person.content\.person\.name\.lref                          lido:actorID                                                identificatie afgebeelde persoon of instelling
+#   Content_person.content\.person\.name                                lido:nameActorSet                                           naam afgebeelde persoon of instelling
+#                                                                   lido:subjectEvent
+#   Content_subject.content\.subject\.lref                              lido:eventID                                                identificatie afgebeelde gebeurtenis
+#   Content_subject.content\.subject                                    lido:eventName                                              naam afgebeelde gebeurtenis
+#                                                                   lido:subjectPlace
+#   Content_subject.content\.subject\.lref                              lido:placeID                                                identificatie afgebeelde locatie
+#   Content_subject.content\.subject                                    lido:namePlaceSet                                           naam afgebeelde locatie
 #                                                       lido:rightsWorkWrap
 #                                                           lido:rightsType
 #                                                               lido:conceptID                                                      identificatie rechten werk
 #                                                               lido:term                                                           term rechten werk
+#                                                           lido:creditLine
 #                                                       lido:recordWrap
 #                                                           lido:recordID
 #   Digital_reference.digital_reference                         type: global                                Data PURL               waarde databanknummer
@@ -171,7 +178,7 @@
 #                                                               lido:term
 #                                                           lido:recordSource
 #                                                               lido:legalBodyID                                                    identificatie data provider
-#   institution\.name.value                                     lido:legalBodyName                                                  naam data provider
+#   institution\.name                                           lido:legalBodyName                                                  naam data provider
 #                                                               lido:legalBodyWeblink
 #                                                           lido:recordRights
 #                                                               lido:rightsType
@@ -192,13 +199,13 @@
     # the ID field looks like this:
     #
     #   oai:datahub.vlaamsekunstcollectie.be:<domain>:<identifier>
-    #   ex. oai:datahub.vlaamsekunstcollectie.be:kmksa.be:254
+    #   ex. oai:datahub.vlaamsekunstcollectie.be:groeningemuseum.be:254
     #   ex. oai:datahub.vlaamsekunstcollectie.be:collectievlaamsegemeenschap.be:837
     #
     # Note: the .tld is stripped from the domainname because the . (dot) breaks the
     # route matching algoritm.
 
-    unless is_array(or_record.pids) 
+    unless is_array(or_record.pids)
         move_field(or_record.pids, or_record.tmp)
         set_array(or_record.pids)
         move_field(or_record.tmp, or_record.pids.$append)
@@ -206,7 +213,7 @@
 
     do list(path:or_record.pids, var: c)
 
-        if all_match('c.digital_reference\.description.value', 'datapid')
+        if all_match('c.digital_reference\.description', 'datapid')
 
             if all_match(c.digital_reference, '.*\S.*')
 
@@ -243,7 +250,7 @@
 
 ### LIDO objectPublishedID
 
-    unless is_array(or_record.workPid) 
+    unless is_array(or_record.workPid)
         move_field(or_record.workPid, or_record.tmp)
         set_array(or_record.workPid)
         move_field(or_record.tmp, or_record.workPid.$append)
@@ -300,19 +307,19 @@
         move_field(or_record.tmp, or_record.object_name.$append)
     end
 
-    # We'll have multiple objectWorkTypes: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
 
     do list(path: or_record.object_name, var: c)
 
         # Value in Adlib
 
-        if all_match(c.object_name.value, '.*\S.*')
+        if all_match(c.object_name, '.*\S.*')
 
             if all_match('c.object_name\.lref', '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$append,
-                    c.object_name.value,
+                    c.object_name,
                     -conceptid: 'c.object_name\.lref',
                     -type: local,
                     -source: Adlib,
@@ -324,7 +331,7 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$append,
-                    c.object_name.value,
+                    c.object_name,
                     -pref: preferred,
                     -lang: nl
                 )
@@ -335,18 +342,18 @@
 
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.object_name.value, c.aat)
+        copy_field(c.object_name, c.object_name_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.object_name_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat.aatterm, '.*\S.*')
+        if all_match(c.object_name_aat.aatterm, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.object_name_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.object_name_aat.aatterm,
+                    -conceptid: c.object_name_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -357,7 +364,7 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$last,
-                    c.aat.aatterm,
+                    c.object_name_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
@@ -368,7 +375,7 @@
 
     end
 
-# LIDO classification [type="objectcategorie"]
+# LIDO classification [type="object-category"]
 
     unless is_array(or_record.object_category) 
         move_field(or_record.object_category, or_record.tmp)
@@ -386,9 +393,9 @@
         copy_field(c, or_record.object_category.$append.id)
     end
 
-    assoc(or_record.object_cat, or_record.object_category.*.id, or_record.object_category.*.value)
+    assoc(or_record.object_cat, or_record.object_category.*.id, or_record.object_category.*)
 
-    # We'll have multiple classifications with type "objectcategorie": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+    # We'll have multiple terms for the type "object-category": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
 
     do each (path: or_record.object_cat, var: c)
 
@@ -419,24 +426,24 @@
 
             end
 
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "objectcategorie")
+            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "object-category")
 
         end
     
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.value, c.aat)
+        copy_field(c.value, c.object_category_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.object_category_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat.aatterm, '.*\S.*')
+        if all_match(c.object_category_aat.aatterm, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.object_category_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.object_category_aat.aatterm,
+                    -conceptid: c.object_category_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -447,106 +454,14 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
+                    c.object_category_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
 
             end
 
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "objectcategorie")
-
-        end
-
-    end
-
-# LIDO classification [type="hoofdmotief"]
-
-    unless is_array(or_record.subject) 
-        move_field(or_record.subject, or_record.tmp)
-        set_array(or_record.subject)
-        move_field(or_record.tmp, or_record.subject.$append)
-    end
-
-    unless is_array(or_record.subject_id)
-        move_field(or_record.subject_id, or_record.tmp)
-        set_array(or_record.subject_id)
-        move_field(or_record.tmp, or_record.subject_id.$append)
-    end
-
-    do list (path: or_record.subject_id, var: c)
-        copy_field(c, or_record.subject.$append.id)
-    end
-
-    assoc(or_record.general_motif, or_record.subject.*.id, or_record.subject.*.value)
-
-    # We'll have multiple classifications with type "hoofdmotief": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
-
-    do each(path: or_record.general_motif, var: c)
-
-        # Value in Adlib
-
-        if all_match(c.value, '.*\S.*')
-
-            if all_match(c.key, '.*\S.*')
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$append,
-                    c.value,
-                    -conceptid: c.key,
-                    -type: local,
-                    -source: Adlib,
-                    -pref: preferred,
-                    -lang: nl
-                )
-
-            else
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$append,
-                    c.value,
-                    -pref: preferred,
-                    -lang: nl
-                )
-
-            end
-
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "hoofdmotief")
-
-        end
-    
-        # Corresponding value in AAT, not (yet) retrievable via API
-
-        copy_field(c.value, c.aat)
-
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
-
-        if all_match(c.aat.aatterm, '.*\S.*')
-
-            if all_match(c.aat.aaturi, '.*\S.*')
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
-                    -type: purl,
-                    -source: AAT,
-                    -pref: alternate,
-                    -lang: nl
-                )
-
-            else
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -pref: alternate,
-                    -lang: nl
-                )
-
-            end
-
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "hoofdmotief")
+            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "object-category")
 
         end
 
@@ -565,11 +480,11 @@
 
     do list(path: or_record.title, var: c)
 
-        if all_match(c.title.value, '.*\S.*')
+        if all_match(c.title, '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.$append,
-                c.title.value,
+                c.title,
                 -value_pref: preferred
             )
 
@@ -607,11 +522,11 @@
 
     do list(path: or_record.institution, var: c)
 
-        if all_match(c.value, '.*\S.*')
+        if all_match(c, '.*\S.*')
 
             lido_basenameset(
-                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.repositoryName.legalBodyName.$append,
-                c.value
+                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$append.repositoryName.legalBodyName,
+                c
             )
 
         end
@@ -631,9 +546,9 @@
         if all_match(c, '.*\S.*')
 
             lido_baseid(
-                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.workID,
+                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$last.workID,
                 c,
-                -type: objectnummer
+                -type: object-number
             )
 
         end
@@ -652,7 +567,10 @@
 
         if all_match(c.description, '.*\S.*')
 
-            copy_field(c.description, descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.$last.descriptiveNoteValue.$append._)
+            lido_descriptivenote(
+                descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet,
+                c.description
+            )
 
         end
 
@@ -670,15 +588,15 @@
 
         add_field(descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$append)
 
-        if all_match('c.dimension\.type.value', '.*\S.*')
+        if all_match('c.dimension\.type', '.*\S.*')
 
-            copy_field('c.dimension\.type.value', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementType._)
+            copy_field('c.dimension\.type', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementType._)
 
         end
 
-        if all_match('c.dimension\.unit.value', '.*\S.*')
+        if all_match('c.dimension\.unit', '.*\S.*')
 
-            copy_field('c.dimension\.unit.value', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementUnit._)
+            copy_field('c.dimension\.unit', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementUnit._)
 
         end
 
@@ -701,88 +619,12 @@
 
 # LIDO eventType [eventType/term="acquisition"]
 
-#    add_field(or_record.event_type, acquisition)
+#    add_field(or_record.event_type, "acquisition")
 
 #    lido_term(
 #        descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
 #        or_record.event_type
 #    )
-
-# LIDO eventMethod [eventType/term="acquisition"]
-
-#    unless is_array(or_record.acquisition_method)
-#        move_field(or_record.acquisition_method, or_record.tmp)
-#        set_array(or_record.acquisition_method)
-#        move_field(or_record.tmp, or_record.acquisition_method.$append)
-#    end
-
-    # We'll have multiple eventMethods: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
-
-#    do list(path:or_record.acquisition_method, var:c)
-
-        # Value in Adlib
-
-#        if all_match(c.value, '.*\S.*')
-
-#            if all_match(or_record.acquisition_method_id, '.*\S.*')
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
-#                    c.value,
-#                    -conceptid: or_record.acquisition_method_id,
-#                    -type: local,
-#                    -source: Adlib,
-#                    -pref: preferred,
-#                    -lang: nl
-#                )
-
-#            else
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
-#                    c.value,
-#                    -pref: preferred,
-#                    -lang: nl
-#                )
-
-#            end
-
-#        end
-
-        # Corresponding value in AAT, not (yet) retrievable via API
-
-#        copy_field(c.value, c.aat)
-
-#        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
-
-#        if all_match(c.aat.aatterm, '.*\S.*')
-
-#            if all_match(c.aat.aaturi, '.*\S.*')
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
-#                    c.aat.aatterm,
-#                    -conceptid: c.aat.aaturi,
-#                    -type: purl,
-#                    -source: AAT,
-#                    -pref: alternate,
-#                    -lang: nl
-#                )
-
-#            else
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
-#                    c.aat.aatterm,
-#                    -pref: alternate,
-#                    -lang: nl
-#                )
-
-#            end
-
-#        end
-
-#    end
 
 # LIDO eventActor [eventType/term="acquisition"]
 
@@ -794,11 +636,12 @@
 
 #    do list (path:or_record.acquisition_source, var:c)
 
-#        if all_match(c, '.*\S.*')
+#        if all_match('c.acquisition\.source', '.*\S.*')
 
-#            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append)
-
-#            copy_field(c, descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.nameActorSet.appellationValue._)
+#            lido_basenameset(
+#                descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append.actorInRole.actor.nameActorSet,
+#                'c.acquisition\.source'
+#            )
 
 #        end
 
@@ -825,9 +668,97 @@
 
 #    end
 
+# LIDO eventMethod [eventType/term="acquisition"]
+
+#    unless is_array(or_record.acquisition_method)
+#        move_field(or_record.acquisition_method, or_record.tmp)
+#        set_array(or_record.acquisition_method)
+#        move_field(or_record.tmp, or_record.acquisition_method.$append)
+#    end
+
+#    unless is_array(or_record.acquisition_method_id)
+#        move_field(or_record.acquisition_method_id, or_record.tmp)
+#        set_array(or_record.acquisition_method_id)
+#        move_field(or_record.tmp, or_record.acquisition_method_id.$append)
+#    end
+
+#    do list (path: or_record.acquisition_method_id, var: c)
+#        copy_field(c, or_record.acquisition_method.$append.id)
+#    end
+
+#    assoc(or_record.acquisition_m, or_record.acquisition_method.*.id, or_record.acquisition_method.*)
+
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+
+#    do each (path:or_record.acquisition_m, var:c)
+
+        # Value in Adlib
+
+#        if all_match(c.value, '.*\S.*')
+
+#            if all_match(c.key, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
+#                    c.value,
+#                    -conceptid: c.key,
+#                    -type: local,
+#                    -source: Adlib,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
+#                    c.value,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+        # Corresponding value in AAT, not (yet) retrievable via API
+
+#        copy_field(c.value, c.acquisition_aat)
+
+#        lookup_in_store(c.acquisition_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+
+#        if all_match(c.acquisition_aat.aatterm, '.*\S.*')
+
+#            if all_match(c.acquisition_aat.aaturi, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
+#                    c.acquisition_aat.aatterm,
+#                    -conceptid: c.acquisition_aat.aaturi,
+#                    -type: purl,
+#                    -source: AAT,
+#                    -pref: alternate,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
+#                    c.acquisition_aat.aatterm,
+#                    -pref: alternate,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+#    end
+
 # LIDO eventType [eventType/term="production"]
 
-    add_field(or_record.event_type, production)
+    add_field(or_record.event_type, "production")
     
     lido_term(
         descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
@@ -846,27 +777,23 @@
 
         trim('c.creator\.qualifier')
 
-        if all_match(c.creator.value, '.*\S.*')
+        if all_match(c.creator, '.*\S.*')
 
             lido_actor(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append,
                 'c.creator\.lref',
-                c.creator.value,
+                c.creator,
                 -id_source: Adlib,
                 -id_type: local,
                 -name_pref: preferred
             )
 
-            unless all_match('c.creator\.qualifier', '.*\S.*')
+            if all_match('c.creator\.date_of_birth', '.*\S.*')
+                copy_field('c.creator\.date_of_birth', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.earliestDate._)
+            end
 
-                if all_match('c.creator\.date_of_birth', '.*\S.*')
-                    copy_field('c.creator\.date_of_birth', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.earliestDate._)
-                end
-
-                if all_match('c.creator\.date_of_death', '.*\S.*')
-                    copy_field('c.creator\.date_of_death', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.latestDate._)
-                end
-
+            if all_match('c.creator\.date_of_death', '.*\S.*')
+                copy_field('c.creator\.date_of_death', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.latestDate._)
             end
 
             if all_match('c.creator\.qualifier', '.*\S.*')
@@ -877,30 +804,30 @@
 
         # Role. Work around. -role switch in lido_actor does not work correctly.
 
-        if all_match('c.creator\.role.value', '.*\S.*')
+        if all_match('c.creator\.role', '.*\S.*')
 
             lido_term(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.roleActor,
-                'c.creator\.role.value',
+                'c.creator\.role',
             )
 
         end
 
         # Add Persistent URI data to actor
 
-        copy_field(c.creator.value, c.creator.pid)
+        copy_field(c.creator, c.creator_pid)
 
-        downcase(c.creator.pid)
+        downcase(c.creator_pid)
 
-        lookup_in_store(c.creator.pid, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
+        lookup_in_store(c.creator_pid, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
 
         # Preferred label from Flemish Art Collection concordance database
 
-        if all_match(c.creator.pid._id, '.*\S.*')
+        if all_match(c.creator_pid._id, '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.nameActorSet.$last,
-                c.creator.pid.display_name,
+                c.creator_pid.display_name,
                 -value_pref: alternate
             )
 
@@ -908,33 +835,33 @@
 
         # Creator Persistent URI's
 
-        if all_match(c.creator.pid.viaf_uri, '.*\S.*')
+        if all_match(c.creator_pid.viaf_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.viaf_uri,
+                c.creator_pid.viaf_uri,
                 -source: VIAF,
                 -type: purl
             )
 
         end
 
-        if all_match(c.creator.pid.rkd_uri, '.*\S.*')
+        if all_match(c.creator_pid.rkd_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.rkd_uri,
+                c.creator_pid.rkd_uri,
                 -source: RKD,
                 -type: purl
             )
 
         end
 
-        if all_match(c.creator.pid.wikidata_uri, '.*\S.*')
+        if all_match(c.creator_pid.wikidata_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.wikidata_uri,
+                c.creator_pid.wikidata_uri,
                 -source: Wikidata,
                 -type: purl
             )
@@ -1001,14 +928,22 @@
 
                 end
 
+            else
+
+                add_field(or_record.displayDate, "incorrect date format")
+
             end
 
         end
 
-        lido_basevalue(
-            descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.displayDate,
-            or_record.displayDate
-        )
+        unless all_match(or_record.displayDate, "incorrect date format")
+
+            lido_basevalue(
+                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.displayDate,
+                or_record.displayDate
+            )
+
+        end
 
     end
 
@@ -1021,11 +956,11 @@
 
         if all_match('d.production\.date\.start', '.*\S.*')
 
-            prepend('d.production\.date\.start', 'vkcdate')
+            prepend('d.production\.date\.start', '#date#')
 
             if all_match('d.production\.date\.start\.prec', '.*\S.*')
 
-                prepend('d.production\.date\.start\.prec', 'vkcprec')
+                prepend('d.production\.date\.start\.prec', '#prec#')
                 paste('d.production\.date\.start','d.production\.date\.start','d.production\.date\.start\.prec',join_char:"")
 
             end
@@ -1036,11 +971,11 @@
 
         if all_match('d.production\.date\.end', '.*\S.*')
 
-            prepend('d.production\.date\.end', 'vkcdate')
+            prepend('d.production\.date\.end', '#date#')
 
             if all_match('d.production\.date\.end\.prec', '.*\S.*')
 
-                prepend('d.production\.date\.end\.prec', 'vkcprec')
+                prepend('d.production\.date\.end\.prec', '#prec#')
                 paste('d.production\.date\.end','d.production\.date\.end','d.production\.date\.end\.prec',join_char:"")
 
             end
@@ -1054,11 +989,11 @@
     if all_match(or_record.earliest_dates.0, '.*\S.*')
 
         sort_field(or_record.earliest_dates)
-        if any_match(or_record.earliest_dates.0, 'vkcdate(.*)vkcprec(.*)')
-            parse_text(or_record.earliest_dates.0, 'vkcdate(.*)vkcprec(.*)')
+        if any_match(or_record.earliest_dates.0, '#date#(.*)#prec#(.*)')
+            parse_text(or_record.earliest_dates.0, '#date#(.*)#prec#(.*)')
         else
-            if any_match(or_record.earliest_dates.0, 'vkcdate(.*)')
-                parse_text(or_record.earliest_dates.0, 'vkcdate(.*)')
+            if any_match(or_record.earliest_dates.0, '#date#(.*)')
+                parse_text(or_record.earliest_dates.0, '#date#(.*)')
             end
         end
 
@@ -1067,11 +1002,11 @@
     if all_match(or_record.latest_dates.0, '.*\S.*')
 
         sort_field(or_record.latest_dates, reverse:1)
-        if any_match(or_record.latest_dates.0, 'vkcdate(.*)vkcprec(.*)')
-            parse_text(or_record.latest_dates.0, 'vkcdate(.*)vkcprec(.*)')
+        if any_match(or_record.latest_dates.0, '#date#(.*)#prec#(.*)')
+            parse_text(or_record.latest_dates.0, '#date#(.*)#prec#(.*)')
         else
-            if any_match(or_record.latest_dates.0, 'vkcdate(.*)')
-                parse_text(or_record.latest_dates.0, 'vkcdate(.*)')
+            if any_match(or_record.latest_dates.0, '#date#(.*)')
+                parse_text(or_record.latest_dates.0, '#date#(.*)')
             end
         end
 
@@ -1079,23 +1014,72 @@
 
     if all_match(or_record.earliest_dates.0.0, '.*\S.*')
 
-        if all_match(or_record.latest_dates.0.0, '.*\S.*')
+        if all_match(or_record.earliest_dates.0.1, '.*\S.*')
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -earliest_date: or_record.earliest_dates.0.0,
-                -earliest_date_type: or_record.earliest_dates.0.1,
-                -latest_date: or_record.latest_dates.0.0,
-                -latest_date_type: or_record.latest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.0, '.*\S.*')
+
+                if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -earliest_date_type: or_record.earliest_dates.0.1,
+                        -latest_date: or_record.latest_dates.0.0,
+                        -latest_date_type: or_record.latest_dates.0.1
+                    )
+
+                else
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -earliest_date_type: or_record.earliest_dates.0.1,
+                        -latest_date: or_record.latest_dates.0.0
+                    )
+
+                end
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -earliest_date: or_record.earliest_dates.0.0,
+                    -earliest_date_type: or_record.earliest_dates.0.1
+                )
+
+            end
 
         else
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -earliest_date: or_record.earliest_dates.0.0,
-                -earliest_date_type: or_record.earliest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.0, '.*\S.*')
+
+                if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -latest_date: or_record.latest_dates.0.0,
+                        -latest_date_type: or_record.latest_dates.0.1
+                    )
+
+                else
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -latest_date: or_record.latest_dates.0.0
+                    )
+
+                end
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -earliest_date: or_record.earliest_dates.0.0,
+                )
+
+            end
 
         end
 
@@ -1103,11 +1087,22 @@
 
         if all_match(or_record.latest_dates.0.0, '.*\S.*')
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -latest_date: or_record.latest_dates.0.0,
-                -latest_date_type: or_record.latest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -latest_date: or_record.latest_dates.0.0,
+                    -latest_date_type: or_record.latest_dates.0.1
+                )
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -latest_date: or_record.latest_dates.0.0
+                )
+
+            end
 
         else
 
@@ -1145,18 +1140,18 @@
         copy_field(c, or_record.production_period.$append.id)
     end
 
-    assoc(or_record.period, or_record.production_period.*.value, or_record.production_period.*.id)
+    assoc(or_record.period, or_record.production_period.*.id, or_record.production_period.*)
 
     do each (path: or_record.period, var: c)
 
-        if all_match(c.key, '.*\S.*')
+        if all_match(c.value, '.*\S.*')
 
-            if all_match(c.value, '.*\S.*')
+            if all_match(c.key, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.periodName.$append,
-                    c.key,
-                    -conceptid: c.value,
+                    c.value,
+                    -conceptid: c.key,
                     -lang: nl,
                     -source: Adlib,
                     -type: local
@@ -1166,7 +1161,7 @@
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.periodName.$append,
-                    c.key,
+                    c.value,
                     -lang: nl
                 )
 
@@ -1178,13 +1173,19 @@
 
 # LIDO namePlaceSet [eventType/term="production"]
 
+    unless is_array(or_record.production)
+        move_field(or_record.production, or_record.tmp)
+        set_array(or_record.production)
+        move_field(or_record.tmp, or_record.production.$append)
+    end
+
     do list (path: or_record.production, var: c)
 
-        if all_match('c.production\.place.value', '.*\S.*')
+        if all_match('c.production\.place', '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventPlace.$append.place.namePlaceSet,
-                'c.production\.place.value',
+                'c.production\.place',
                 -value_pref: preferred,
                 -value_lang: nl
             )
@@ -1212,19 +1213,21 @@
         move_field(or_record.tmp, or_record.materials.$append)
     end
 
-    # We'll have multiple termMaterialsTechs: the corresponding value in AAT (type:alternate) and the value from the Adlib field object_name itself (type:preferred)
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from the Adlib field object_name itself (type:preferred)
 
     do list(path: or_record.materials, var: c)
 
         # Value in Adlib
 
-        if all_match(c.material.value, '.*\S.*')
+        if all_match(c.material, '.*\S.*')
+
+            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append.type, "material")
 
             if all_match('c.material\.lref', '.*\S.*')
 
                 lido_term(
-                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append,
-                    c.material.value,
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+                    c.material,
                     -conceptid: 'c.material\.lref',
                     -type: local,
                     -source: Adlib,
@@ -1235,8 +1238,8 @@
             else
 
                 lido_term(
-                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append,
-                    c.material.value,
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+                    c.material,
                     -pref: preferred,
                     -lang: nl
                 )
@@ -1247,18 +1250,18 @@
 
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.material.value, c.aat)
+        copy_field(c.material, c.material_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.material_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat._id, '.*\S.*')
+        if all_match(c.material_aat._id, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.material_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.material_aat.aatterm,
+                    -conceptid: c.material_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -1269,7 +1272,7 @@
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
-                    c.aat.aatterm,
+                    c.material_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
@@ -1306,6 +1309,98 @@
 
 # LIDO subjectConcept / subjectEvent / subjectPlace
 
+    # Content motif general
+
+    unless is_array(or_record.content_motif_general)
+        move_field(or_record.content_motif_general, or_record.tmp)
+        set_array(or_record.content_motif_general)
+        move_field(or_record.tmp, or_record.content_motif_general.$append)
+    end
+
+    unless is_array(or_record.content_motif_general_id)
+        move_field(or_record.content_motif_general_id, or_record.tmp)
+        set_array(or_record.content_motif_general_id)
+        move_field(or_record.tmp, or_record.content_motif_general_id.$append)
+    end
+
+    do list(path:or_record.content_motif_general_id, var:c)
+        copy_field(c, or_record.content_motif_general.$append.id)
+    end
+
+    assoc(or_record.general_motif, or_record.content_motif_general.*.id, or_record.content_motif_general.*)
+
+    # We'll have multiple terms for the type "content-motif-general": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+
+    do each(path:or_record.general_motif, var:c)
+
+        # Value in Adlib
+
+        if all_match(c.value, '.*\S.*')
+
+            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "content-motif-general")
+
+            if all_match(c.key, '.*\S.*')
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+                    c.value,
+                    -conceptid: c.key,
+                    -type: local,
+                    -source: Adlib,
+                    -pref: preferred,
+                    -lang: nl
+                )
+
+            else
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+                    c.value,
+                    -pref: preferred,
+                    -lang: nl
+                )
+
+            end
+
+        end
+
+        # Corresponding value in AAT, not (yet) retrievable via API
+
+        copy_field(c.value, c.general_motif_aat)
+
+        lookup_in_store(c.general_motif_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+
+        if all_match(c.general_motif_aat.aatterm, '.*\S.*')
+
+            if all_match(c.general_motif_aat.aaturi, '.*\S.*')
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$last,
+                    c.general_motif_aat.aatterm,
+                    -conceptid: c.general_motif_aat.aaturi,
+                    -type: purl,
+                    -source: AAT,
+                    -pref: alternate,
+                    -lang: nl
+                )
+
+            else
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$last,
+                    c.general_motif_aat.aatterm,
+                    -pref: alternate,
+                    -lang: nl
+                )
+
+            end
+
+        end
+
+    end
+
+    # Depicted subject
+
     unless is_array(or_record.depicted_subject) 
         move_field(or_record.depicted_subject, or_record.tmp)
         set_array(or_record.depicted_subject)
@@ -1314,15 +1409,13 @@
 
     do list(path:or_record.depicted_subject, var:c)
 
-        if all_match('c.content\.subject.value', '.*\S.*')
+        if all_match('c.content\.subject', '.*\S.*')
 
             if all_match('c.content\.subject\.type.value.2.content', 'geografie')
 
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectPlace.$append)
-
                 lido_basenameset(
-                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectPlace.$last.place.namePlaceSet,
-                    'c.content\.subject.value'
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectPlace.$append.place.namePlaceSet,
+                    'c.content\.subject'
                 )
 
                 if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1340,13 +1433,11 @@
 
                 if all_match('c.content\.subject\.type.value.2.content', 'gebeurtenis')
 
-                    add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$append)
-
                     set_field(or_record.event_type, event)
                     set_field(or_record.event_type_URI, 'http://www.cidoc-crm.org/Entity/e5-event/version-6.2')
 
                     lido_term(
-                        descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventType,
+                        descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectEvent.$append.event.eventType,
                         or_record.event_type,
                         -conceptid: or_record.event_type_URI,
                         -type: purl,
@@ -1355,7 +1446,7 @@
 
                     lido_basenameset(
                         descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventName,
-                        'c.content\.subject.value'
+                        'c.content\.subject'
                     )
 
                     if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1373,13 +1464,11 @@
 
                     if all_match('c.content\.subject\.type.value.2.content', 'activiteit')
 
-                        add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$append)
-
                         set_field(or_record.event_type, activity)
                         set_field(or_record.event_type_URI, 'http://www.cidoc-crm.org/Entity/e7-activity/version-6.2')
 
                         lido_term(
-                            descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventType,
+                            descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectEvent.$append.event.eventType,
                             or_record.event_type,
                             -conceptid: or_record.event_type_URI,
                             -type: purl,
@@ -1388,7 +1477,7 @@
 
                         lido_basenameset(
                             descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventName,
-                            'c.content\.subject.value'
+                            'c.content\.subject'
                         )
 
                         if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1407,8 +1496,8 @@
                         if all_match('c.content\.subject\.lref', '.*\S.*')
 
                             lido_term(
-                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
-                                'c.content\.subject.value',
+                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectConcept.$append,
+                                'c.content\.subject',
                                 -conceptid: 'c.content\.subject\.lref',
                                 -type: local,
                                 -source: Adlib
@@ -1417,8 +1506,8 @@
                         else
 
                             lido_term(
-                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
-                                'c.content\.subject.value'
+                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectConcept.$append,
+                                'c.content\.subject'
                             )
 
                         end
@@ -1443,19 +1532,21 @@
 
     do list(path:or_record.depicted_person, var:c)
 
-        if all_match('c.content\.person\.name.value', '.*\S.*')
+        if all_match('c.content\.person\.name', '.*\S.*')
 
-            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$append)
-
-            copy_field('c.content\.person\.name.value', descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.nameActorSet.appellationValue._)
+            lido_basenameset(
+                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectActor.$append.actor.nameActorSet,
+                'c.content\.person\.name'
+            )
 
             if all_match('c.content\.person\.name\.lref', '.*\S.*')
 
-                copy_field('c.content\.person\.name\.lref', descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID._)
-
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID.type, "local")
-
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID.source, "Adlib")
+                lido_baseid(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID,
+                    'c.content\.person\.name\.lref',
+                    -type: local,
+                    -source: Adlib
+                )
 
             end
 
@@ -1467,13 +1558,33 @@
 
 ### LIDO administrativeMetadata
 
+## LIDO rightsWorkWrap
+
+# LIDO creditLine
+
+    do list(path: or_record.object_number, var: c)
+
+        lookup_in_store(c, DBI, data_source: 'dbi:SQLite:/tmp/import.RIGHTS.sqlite')
+
+        if all_match(c.rights, '.*\S.*')
+
+            lido_basevalue(
+                administrativeMetadata.rightsWorkWrap.rightsWorkSet.creditLine,
+                c.rights
+            )
+
+        end
+
+    end
+
+
 ## LIDO recordWrap
 
 # LIDO recordID
 
     do list(path:or_record.pids, var: c)
 
-        if all_match('c.digital_reference\.description.value', 'datapid')
+        if all_match('c.digital_reference\.description', 'datapid')
 
             if all_match(c.digital_reference, '.*\S.*')
 
@@ -1544,11 +1655,11 @@
 
     do list(path: or_record.institution, var: c)
 
-        if all_match(c.value, '.*\S.*')
+        if all_match(c, '.*\S.*')
 
             lido_basenameset(
-                administrativeMetadata.recordWrap.recordSource.legalBodyName.$append,
-                c.value
+                administrativeMetadata.recordWrap.recordSource.legalBodyName,
+                c
             )
 
         end
@@ -1569,12 +1680,13 @@
 
     do list(path:or_record.pids, var: c)
 
-        if all_match('c.digital_reference\.description.value', 'representationpid')
+        if all_match('c.digital_reference\.description', 'representationpid')
 
             if all_match(c.digital_reference, '.*\S.*')
 
                 copy_field(c.digital_reference, administrativeMetadata.resourceWrap.resourceSet.resourceID._)
                 add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.type, "purl")
+                add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.label, "representationPID")
 
                 copy_field(c.digital_reference, administrativeMetadata.resourceWrap.resourceSet.resourceRepresentation.linkResource._)
 

--- a/msk_oai_adlib.fix
+++ b/msk_oai_adlib.fix
@@ -15,26 +15,26 @@
     copy_field(_metadata.Object_name, or_record.object_name)
     copy_field(_metadata.object_category, or_record.object_category)
     copy_field('_metadata.object_category\.lref', or_record.object_category_id)
-    copy_field('_metadata.content\.motif\.general', or_record.subject)
-    copy_field('_metadata.content\.motif\.general\.lref', or_record.subject_id)
     copy_field(_metadata.Title, or_record.title)
     copy_field(_metadata.Titel_translation, or_record.title_translation)
     copy_field('_metadata.institution\.name', or_record.institution)
     copy_field(_metadata.object_number, or_record.object_number)
     copy_field(_metadata.Description, or_record.description)
     copy_field(_metadata.Dimension, or_record.dimensions)
+#    copy_field(_metadata.Acquisition_source, or_record.acquisition_source)
+#    copy_field('_metadata.acquisition\.date', or_record.acquisition_date)
 #    copy_field('_metadata.acquisition\.method', or_record.acquisition_method)
 #    copy_field('_metadata.acquisition\.method\.lref', or_record.acquisition_method_id)
-#    copy_field('_metadata.Acquisition_source.acquisition\.source.value', or_record.acquisition_source)
-#    copy_field('_metadata.acquisition\.date', or_record.acquisition_date)
     copy_field(_metadata.Production, or_record.production)
     copy_field(_metadata.Production_date, or_record.production_date)
     copy_field('_metadata.production\.period', or_record.production_period)
     copy_field('_metadata.production\.period\.lref', or_record.production_period_id)
     copy_field(_metadata.Material, or_record.materials)
     copy_field(_metadata.physical_description, or_record.physical_description)
-    copy_field(_metadata.Content_person, or_record.depicted_person)
+    copy_field('_metadata.content\.motif\.general', or_record.content_motif_general)
+    copy_field('_metadata.content\.motif\.general\.lref', or_record.content_motif_general_id)
     copy_field(_metadata.Content_subject, or_record.depicted_subject)
+    copy_field(_metadata.Content_person, or_record.depicted_person)
     copy_field(_metadata.priref, or_record.priref)
 
 # Remove all Adlib fields, retaining only the fields to create the lido structure
@@ -61,36 +61,33 @@
 #   Object_name.object_name                                     pref: preferred                             Subtype                 term objectnaam
 #                                                               pref: alternate                             Subtype
 #                                                       lido:classification
-#                                                           type: objectcategorie
+#                                                           type: object-category
 #                                                               lido:conceptID
 #   object_category.\lref                                           pref: preferred
 #                                                                   pref: alternate                                                 identificatie
 #                                                               lido:term
 #   object_category                                                 pref: preferred                         Type                    term
 #                                                                   pref: alternate                         Type
-#                                                           type: hoofdmotief
-#                                                               lido:conceptID
-#   content\.motif\.general\.lref                                   pref: preferred
-#                                                                   pref: alternate                                                 identificatie hoofdmotief
-#                                                               lido:term
-#   content\.motif\.general                                         pref: preferred                         Onderwerp               term hoofdmotief
-#                                                                   pref: alternate                         Onderwerp
 #                                                       lido:titleSet
 #   Title                                                   pref: preferred                                                         titel
 #   Titel_translation                                       pref: alternate
-#   institution\.name.value                             lido:repositoryName                                 Instelling              naam bewaarinstelling
-#                                                       lido:workID
-#   object_number                                           type: objectnummer                              Inventarisnummer        waarde objectnummer
+#                                                       lido:repositorySet
+#   institution\.name                                       lido:repositoryName                             Instelling              naam bewaarinstelling
+#                                                           lido:workID
+#   object_number                                               type: object-number                         Inventarisnummer        waarde objectnummer
 #   Description                                         lido:objectDescriptionSet                           Beschrijving            korte beschrijving
 #                                                       lido:objectMeasurementsSet
 #                                                           lido:measurementsSet
-#   Dimension.dimension\.type.value                             lido:measurementType                        Dimensies               dimensie afmeting
-#   Dimension.dimension\.unit.value                             lido:measurementUnit                        Dimensies               eenheid afmeting
+#   Dimension.dimension\.type                                   lido:measurementType                                                dimensie afmeting
+#   Dimension.dimension\.unit                                   lido:measurementUnit                        Dimensies               eenheid afmeting
 #   Dimension.dimension\.value                                  lido:measurementValue                       Dimensies               waarde afmeting
 #   Dimension.dimension\.part                               lido:extentMeasurements                                                 onderdeel afmeting
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               acquisition
+#   Acquisition_source.acquisition\.source                          lido:eventActor                                                 naam verwervingsbron
+#                                                                   lido:eventDate
+#   acquisition\.date                                                   lido:displayDate                                            waarde verwervingdatum
 #                                                                   lido:eventMethod
 #                                                                       lido:conceptID
 #   acquisition\.method\.lref                                               pref: preferred
@@ -98,10 +95,6 @@
 #                                                                       lido:term
 #   acquisition\.method                                                     pref: preferred                                         term verwervingsmethode
 #                                                                           pref: alternate
-#                                                                   lido:eventActor
-#   Acquisition_source                                                  lido:nameActorSet                                           naam verwervingsbron
-#                                                                   lido:eventDate
-#   acquisition\.date                                                   lido:displayDate                                            waarde verwervingdatum
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               production
@@ -109,13 +102,13 @@
 #                                                                       lido:actorID
 #   Production.creator\.lref                                                type: local
 #                                                                           type: purl                                              identificatie vervaardiger
-#   Production.creator.value                                            lido:nameActorSet
+#   Production.creator                                                  lido:nameActorSet
 #                                                                           pref: preferred                 Vervaardiger            naam vervaardiger
 #                                                                           pref: alternate
 #                                                                       lido:vitalDatesActor
 #   Production.creator\.date_of_birth                                       lido:earliestDate
 #   Production.creator\.date_of_death                                       lido:latestDate
-#   Production.creator\.role.value                                      lido:roleActor                      Vervaardiger            rol vervaardiger
+#   Production.creator\.role                                            lido:roleActor                      Vervaardiger            rol vervaardiger
 #   Production.creator\.qualifier                                       lido:attributionQualifierActor      Vervaardiger            kwalificatie vervaardiger
 #                                                                   lido:eventDate
 #                                                                       lido:displayDate                    Datering
@@ -130,15 +123,16 @@
 #                                                                       lido:placeID
 #   Production.production\.place\.lref                                      type: local
 #                                                                       lido:namePlaceSet
-#   Production.production\.place.value                                      type: preferred
+#   Production.production\.place                                            type: preferred
 #                                                                   lido:termMaterialsTech
-#                                                                       lido:conceptID
-#   Material.material\.lref                                                 pref: preferred
-#                                                                           pref: alternate                                         identificatie materiaal
-#                                                                       lido:term
-#   Material.material.value                                                 pref: preferred                                         term materiaal
-#                                                                           pref: alternate
-#   physical_description                                            lido:displayMaterialsTech               Materiaal
+#                                                                       type: material
+#                                                                           lido:conceptID
+#   Material.material\.lref                                                     pref: preferred
+#                                                                               pref: alternate                                     identificatie materiaal
+#                                                                           lido:term
+#   Material.material                                                           pref: preferred             Materiaal               term materiaal
+#                                                                               pref: alternate
+#   physical_description                                            lido:displayMaterialsTech
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               check
@@ -147,21 +141,34 @@
 #                                                                       lido:nameActorSet                                           assessor conditie
 #                                                                   lido:eventDate
 #                                                                       lido:displayDate                                            datum conditie
-#                                                       lido:subject
-#                                                           lido:type
-#                                                               lido:subjectConcept
-#   Content_subject.content\.subject\.lref                          lido:conceptID                                                  identificatie afgebeeld concept
-#   Content_subject.content\.subject.value                          lido:term                                                       term afgebeeld concept
-#                                                               lido:subjectPlace
-#   Content_subject.content\.subject\.lref                          lido:placeID                                                    identificatie afgebeelde locatie
-#   Content_subject.content\.subject.value                          lido:namePlaceSet                                               naam afgebeelde locatie
-#                                                               lido:subjectActor
-#   Content_person.content\.person\.name\.lref                      lido:actorID                                                    identificatie afgebeelde persoon of instelling
-#   Content_person.content\.person\.name.value                      lido:nameActorSet                                               naam afgebeelde persoon of instelling
+#                                                       lido:objectRelationWrap
+#                                                           lido:subject
+#                                                               type: content-motif-general
+#                                                                   lido:subjectConcept
+#                                                                       lido:conceptID
+#   content\.motif\.general\.lref                                           pref: preferred
+#                                                                           pref: alternate                                         identificatie hoofdmotief
+#                                                                       lido:term
+#   content\.motif\.general                                                 pref: preferred                 Onderwerp               term hoofdmotief
+#                                                                           pref: alternate                 Onderwerp
+#                                                               no type
+#                                                                   lido:subjectConcept
+#   Content_subject.content\.subject\.lref                              lido:conceptID                                              identificatie afgebeeld concept
+#   Content_subject.content\.subject                                    lido:term                                                   term afgebeeld concept
+#                                                                   lido:subjectActor
+#   Content_person.content\.person\.name\.lref                          lido:actorID                                                identificatie afgebeelde persoon of instelling
+#   Content_person.content\.person\.name                                lido:nameActorSet                                           naam afgebeelde persoon of instelling
+#                                                                   lido:subjectEvent
+#   Content_subject.content\.subject\.lref                              lido:eventID                                                identificatie afgebeelde gebeurtenis
+#   Content_subject.content\.subject                                    lido:eventName                                              naam afgebeelde gebeurtenis
+#                                                                   lido:subjectPlace
+#   Content_subject.content\.subject\.lref                              lido:placeID                                                identificatie afgebeelde locatie
+#   Content_subject.content\.subject                                    lido:namePlaceSet                                           naam afgebeelde locatie
 #                                                       lido:rightsWorkWrap
 #                                                           lido:rightsType
 #                                                               lido:conceptID                                                      identificatie rechten werk
 #                                                               lido:term                                                           term rechten werk
+#                                                           lido:creditLine
 #                                                       lido:recordWrap
 #                                                           lido:recordID
 #   Digital_reference.digital_reference                         type: global                                Data PURL               waarde databanknummer
@@ -171,7 +178,7 @@
 #                                                               lido:term
 #                                                           lido:recordSource
 #                                                               lido:legalBodyID                                                    identificatie data provider
-#   institution\.name.value                                     lido:legalBodyName                                                  naam data provider
+#   institution\.name                                           lido:legalBodyName                                                  naam data provider
 #                                                               lido:legalBodyWeblink
 #                                                           lido:recordRights
 #                                                               lido:rightsType
@@ -192,13 +199,13 @@
     # the ID field looks like this:
     #
     #   oai:datahub.vlaamsekunstcollectie.be:<domain>:<identifier>
-    #   ex. oai:datahub.vlaamsekunstcollectie.be:kmksa.be:254
+    #   ex. oai:datahub.vlaamsekunstcollectie.be:mskgent.be:254
     #   ex. oai:datahub.vlaamsekunstcollectie.be:collectievlaamsegemeenschap.be:837
     #
     # Note: the .tld is stripped from the domainname because the . (dot) breaks the
     # route matching algoritm.
 
-#    unless is_array(or_record.pids) 
+#    unless is_array(or_record.pids)
 #        move_field(or_record.pids, or_record.tmp)
 #        set_array(or_record.pids)
 #        move_field(or_record.tmp, or_record.pids.$append)
@@ -206,7 +213,7 @@
 
 #    do list(path:or_record.pids, var: c)
 
-#        if all_match('c.digital_reference\.description.value', 'datapid')
+#        if all_match('c.digital_reference\.description', 'datapid')
 
 #            if all_match(c.digital_reference, '.*\S.*')
 
@@ -274,7 +281,7 @@
 
 ### LIDO objectPublishedID
 
-#    unless is_array(or_record.workPid) 
+#    unless is_array(or_record.workPid)
 #        move_field(or_record.workPid, or_record.tmp)
 #        set_array(or_record.workPid)
 #        move_field(or_record.tmp, or_record.workPid.$append)
@@ -343,19 +350,19 @@
         move_field(or_record.tmp, or_record.object_name.$append)
     end
 
-    # We'll have multiple objectWorkTypes: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
 
     do list(path: or_record.object_name, var: c)
 
         # Value in Adlib
 
-        if all_match(c.object_name.value, '.*\S.*')
+        if all_match(c.object_name, '.*\S.*')
 
             if all_match('c.object_name\.lref', '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$append,
-                    c.object_name.value,
+                    c.object_name,
                     -conceptid: 'c.object_name\.lref',
                     -type: local,
                     -source: Adlib,
@@ -367,7 +374,7 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$append,
-                    c.object_name.value,
+                    c.object_name,
                     -pref: preferred,
                     -lang: nl
                 )
@@ -378,18 +385,18 @@
 
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.object_name.value, c.aat)
+        copy_field(c.object_name, c.object_name_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.object_name_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat.aatterm, '.*\S.*')
+        if all_match(c.object_name_aat.aatterm, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.object_name_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.object_name_aat.aatterm,
+                    -conceptid: c.object_name_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -400,7 +407,7 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$last,
-                    c.aat.aatterm,
+                    c.object_name_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
@@ -411,7 +418,7 @@
 
     end
 
-# LIDO classification [type="objectcategorie"]
+# LIDO classification [type="object-category"]
 
     unless is_array(or_record.object_category) 
         move_field(or_record.object_category, or_record.tmp)
@@ -429,9 +436,9 @@
         copy_field(c, or_record.object_category.$append.id)
     end
 
-    assoc(or_record.object_cat, or_record.object_category.*.id, or_record.object_category.*.value)
+    assoc(or_record.object_cat, or_record.object_category.*.id, or_record.object_category.*)
 
-    # We'll have multiple classifications with type "objectcategorie": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+    # We'll have multiple terms for the type "object-category": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
 
     do each (path: or_record.object_cat, var: c)
 
@@ -462,24 +469,24 @@
 
             end
 
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "objectcategorie")
+            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "object-category")
 
         end
     
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.value, c.aat)
+        copy_field(c.value, c.object_category_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.object_category_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat.aatterm, '.*\S.*')
+        if all_match(c.object_category_aat.aatterm, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.object_category_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.object_category_aat.aatterm,
+                    -conceptid: c.object_category_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -490,106 +497,14 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
+                    c.object_category_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
 
             end
 
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "objectcategorie")
-
-        end
-
-    end
-
-# LIDO classification [type="hoofdmotief"]
-
-    unless is_array(or_record.subject) 
-        move_field(or_record.subject, or_record.tmp)
-        set_array(or_record.subject)
-        move_field(or_record.tmp, or_record.subject.$append)
-    end
-
-    unless is_array(or_record.subject_id)
-        move_field(or_record.subject_id, or_record.tmp)
-        set_array(or_record.subject_id)
-        move_field(or_record.tmp, or_record.subject_id.$append)
-    end
-
-    do list (path: or_record.subject_id, var: c)
-        copy_field(c, or_record.subject.$append.id)
-    end
-
-    assoc(or_record.general_motif, or_record.subject.*.id, or_record.subject.*.value)
-
-    # We'll have multiple classifications with type "hoofdmotief": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
-
-    do each(path: or_record.general_motif, var: c)
-
-        # Value in Adlib
-
-        if all_match(c.value, '.*\S.*')
-
-            if all_match(c.key, '.*\S.*')
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$append,
-                    c.value,
-                    -conceptid: c.key,
-                    -type: local,
-                    -source: Adlib,
-                    -pref: preferred,
-                    -lang: nl
-                )
-
-            else
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$append,
-                    c.value,
-                    -pref: preferred,
-                    -lang: nl
-                )
-
-            end
-
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "hoofdmotief")
-
-        end
-    
-        # Corresponding value in AAT, not (yet) retrievable via API
-
-        copy_field(c.value, c.aat)
-
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
-
-        if all_match(c.aat.aatterm, '.*\S.*')
-
-            if all_match(c.aat.aaturi, '.*\S.*')
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
-                    -type: purl,
-                    -source: AAT,
-                    -pref: alternate,
-                    -lang: nl
-                )
-
-            else
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -pref: alternate,
-                    -lang: nl
-                )
-
-            end
-
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "hoofdmotief")
+            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "object-category")
 
         end
 
@@ -608,11 +523,11 @@
 
     do list(path: or_record.title, var: c)
 
-        if all_match(c.title.value, '.*\S.*')
+        if all_match(c.title, '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.$append,
-                c.title.value,
+                c.title,
                 -value_pref: preferred
             )
 
@@ -650,11 +565,11 @@
 
     do list(path: or_record.institution, var: c)
 
-        if all_match(c.value, '.*\S.*')
+        if all_match(c, '.*\S.*')
 
             lido_basenameset(
-                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.repositoryName.legalBodyName.$append,
-                c.value
+                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$append.repositoryName.legalBodyName,
+                c
             )
 
         end
@@ -674,9 +589,9 @@
         if all_match(c, '.*\S.*')
 
             lido_baseid(
-                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.workID,
+                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$last.workID,
                 c,
-                -type: objectnummer
+                -type: object-number
             )
 
         end
@@ -695,7 +610,10 @@
 
         if all_match(c.description, '.*\S.*')
 
-            copy_field(c.description, descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.$last.descriptiveNoteValue.$append._)
+            lido_descriptivenote(
+                descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet,
+                c.description
+            )
 
         end
 
@@ -713,15 +631,15 @@
 
         add_field(descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$append)
 
-        if all_match('c.dimension\.type.value', '.*\S.*')
+        if all_match('c.dimension\.type', '.*\S.*')
 
-            copy_field('c.dimension\.type.value', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementType._)
+            copy_field('c.dimension\.type', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementType._)
 
         end
 
-        if all_match('c.dimension\.unit.value', '.*\S.*')
+        if all_match('c.dimension\.unit', '.*\S.*')
 
-            copy_field('c.dimension\.unit.value', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementUnit._)
+            copy_field('c.dimension\.unit', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementUnit._)
 
         end
 
@@ -744,88 +662,12 @@
 
 # LIDO eventType [eventType/term="acquisition"]
 
-#    add_field(or_record.event_type, acquisition)
+#    add_field(or_record.event_type, "acquisition")
 
 #    lido_term(
 #        descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
 #        or_record.event_type
 #    )
-
-# LIDO eventMethod [eventType/term="acquisition"]
-
-#    unless is_array(or_record.acquisition_method)
-#        move_field(or_record.acquisition_method, or_record.tmp)
-#        set_array(or_record.acquisition_method)
-#        move_field(or_record.tmp, or_record.acquisition_method.$append)
-#    end
-
-    # We'll have multiple eventMethods: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
-
-#    do list(path:or_record.acquisition_method, var:c)
-
-        # Value in Adlib
-
-#        if all_match(c.value, '.*\S.*')
-
-#            if all_match(or_record.acquisition_method_id, '.*\S.*')
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
-#                    c.value,
-#                    -conceptid: or_record.acquisition_method_id,
-#                    -type: local,
-#                    -source: Adlib,
-#                    -pref: preferred,
-#                    -lang: nl
-#                )
-
-#            else
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
-#                    c.value,
-#                    -pref: preferred,
-#                    -lang: nl
-#                )
-
-#            end
-
-#        end
-
-        # Corresponding value in AAT, not (yet) retrievable via API
-
-#        copy_field(c.value, c.aat)
-
-#        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
-
-#        if all_match(c.aat.aatterm, '.*\S.*')
-
-#            if all_match(c.aat.aaturi, '.*\S.*')
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
-#                    c.aat.aatterm,
-#                    -conceptid: c.aat.aaturi,
-#                    -type: purl,
-#                    -source: AAT,
-#                    -pref: alternate,
-#                    -lang: nl
-#                )
-
-#            else
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
-#                    c.aat.aatterm,
-#                    -pref: alternate,
-#                    -lang: nl
-#                )
-
-#            end
-
-#        end
-
-#    end
 
 # LIDO eventActor [eventType/term="acquisition"]
 
@@ -837,11 +679,12 @@
 
 #    do list (path:or_record.acquisition_source, var:c)
 
-#        if all_match(c, '.*\S.*')
+#        if all_match('c.acquisition\.source', '.*\S.*')
 
-#            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append)
-
-#            copy_field(c, descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.nameActorSet.appellationValue._)
+#            lido_basenameset(
+#                descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append.actorInRole.actor.nameActorSet,
+#                'c.acquisition\.source'
+#            )
 
 #        end
 
@@ -868,10 +711,98 @@
 
 #    end
 
+# LIDO eventMethod [eventType/term="acquisition"]
+
+#    unless is_array(or_record.acquisition_method)
+#        move_field(or_record.acquisition_method, or_record.tmp)
+#        set_array(or_record.acquisition_method)
+#        move_field(or_record.tmp, or_record.acquisition_method.$append)
+#    end
+
+#    unless is_array(or_record.acquisition_method_id)
+#        move_field(or_record.acquisition_method_id, or_record.tmp)
+#        set_array(or_record.acquisition_method_id)
+#        move_field(or_record.tmp, or_record.acquisition_method_id.$append)
+#    end
+
+#    do list (path: or_record.acquisition_method_id, var: c)
+#        copy_field(c, or_record.acquisition_method.$append.id)
+#    end
+
+#    assoc(or_record.acquisition_m, or_record.acquisition_method.*.id, or_record.acquisition_method.*)
+
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+
+#    do each (path:or_record.acquisition_m, var:c)
+
+        # Value in Adlib
+
+#        if all_match(c.value, '.*\S.*')
+
+#            if all_match(c.key, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
+#                    c.value,
+#                    -conceptid: c.key,
+#                    -type: local,
+#                    -source: Adlib,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
+#                    c.value,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+        # Corresponding value in AAT, not (yet) retrievable via API
+
+#        copy_field(c.value, c.acquisition_aat)
+
+#        lookup_in_store(c.acquisition_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+
+#        if all_match(c.acquisition_aat.aatterm, '.*\S.*')
+
+#            if all_match(c.acquisition_aat.aaturi, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
+#                    c.acquisition_aat.aatterm,
+#                    -conceptid: c.acquisition_aat.aaturi,
+#                    -type: purl,
+#                    -source: AAT,
+#                    -pref: alternate,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
+#                    c.acquisition_aat.aatterm,
+#                    -pref: alternate,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+#    end
+
 # LIDO eventType [eventType/term="production"]
 
-    add_field(or_record.event_type, production)
-
+    add_field(or_record.event_type, "production")
+    
     lido_term(
         descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
         or_record.event_type
@@ -889,27 +820,23 @@
 
         trim('c.creator\.qualifier')
 
-        if all_match(c.creator.value, '.*\S.*')
+        if all_match(c.creator, '.*\S.*')
 
             lido_actor(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append,
                 'c.creator\.lref',
-                c.creator.value,
+                c.creator,
                 -id_source: Adlib,
                 -id_type: local,
                 -name_pref: preferred
             )
 
-            unless all_match('c.creator\.qualifier', '.*\S.*')
+            if all_match('c.creator\.date_of_birth', '.*\S.*')
+                copy_field('c.creator\.date_of_birth', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.earliestDate._)
+            end
 
-                if all_match('c.creator\.date_of_birth', '.*\S.*')
-                    copy_field('c.creator\.date_of_birth', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.earliestDate._)
-                end
-
-                if all_match('c.creator\.date_of_death', '.*\S.*')
-                    copy_field('c.creator\.date_of_death', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.latestDate._)
-                end
-
+            if all_match('c.creator\.date_of_death', '.*\S.*')
+                copy_field('c.creator\.date_of_death', descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.vitalDatesActor.latestDate._)
             end
 
             if all_match('c.creator\.qualifier', '.*\S.*')
@@ -920,30 +847,30 @@
 
         # Role. Work around. -role switch in lido_actor does not work correctly.
 
-        if all_match('c.creator\.role.value', '.*\S.*')
+        if all_match('c.creator\.role', '.*\S.*')
 
             lido_term(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.roleActor,
-                'c.creator\.role.value',
+                'c.creator\.role',
             )
 
         end
 
         # Add Persistent URI data to actor
 
-        copy_field(c.creator.value, c.creator.pid)
+        copy_field(c.creator, c.creator_pid)
 
-        downcase(c.creator.pid)
+        downcase(c.creator_pid)
 
-        lookup_in_store(c.creator.pid, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
+        lookup_in_store(c.creator_pid, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
 
         # Preferred label from Flemish Art Collection concordance database
 
-        if all_match(c.creator.pid._id, '.*\S.*')
+        if all_match(c.creator_pid._id, '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.nameActorSet.$last,
-                c.creator.pid.display_name,
+                c.creator_pid.display_name,
                 -value_pref: alternate
             )
 
@@ -951,33 +878,33 @@
 
         # Creator Persistent URI's
 
-        if all_match(c.creator.pid.viaf_uri, '.*\S.*')
+        if all_match(c.creator_pid.viaf_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.viaf_uri,
+                c.creator_pid.viaf_uri,
                 -source: VIAF,
                 -type: purl
             )
 
         end
 
-        if all_match(c.creator.pid.rkd_uri, '.*\S.*')
+        if all_match(c.creator_pid.rkd_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.rkd_uri,
+                c.creator_pid.rkd_uri,
                 -source: RKD,
                 -type: purl
             )
 
         end
 
-        if all_match(c.creator.pid.wikidata_uri, '.*\S.*')
+        if all_match(c.creator_pid.wikidata_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.wikidata_uri,
+                c.creator_pid.wikidata_uri,
                 -source: Wikidata,
                 -type: purl
             )
@@ -1003,7 +930,7 @@
                 if in('d.production\.date\.start', 'd.production\.date\.end')
 
                     copy_field('d.production\.date\.start', or_record.displayDate)
-                    
+
                 else
 
                     if all_match('d.production\.date\.end\.prec', '.*\S.*')
@@ -1044,14 +971,22 @@
 
                 end
 
+            else
+
+                add_field(or_record.displayDate, "incorrect date format")
+
             end
 
         end
 
-        lido_basevalue(
-            descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.displayDate,
-            or_record.displayDate
-        )
+        unless all_match(or_record.displayDate, "incorrect date format")
+
+            lido_basevalue(
+                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.displayDate,
+                or_record.displayDate
+            )
+
+        end
 
     end
 
@@ -1064,11 +999,11 @@
 
         if all_match('d.production\.date\.start', '.*\S.*')
 
-            prepend('d.production\.date\.start', 'vkcdate')
+            prepend('d.production\.date\.start', '#date#')
 
             if all_match('d.production\.date\.start\.prec', '.*\S.*')
 
-                prepend('d.production\.date\.start\.prec', 'vkcprec')
+                prepend('d.production\.date\.start\.prec', '#prec#')
                 paste('d.production\.date\.start','d.production\.date\.start','d.production\.date\.start\.prec',join_char:"")
 
             end
@@ -1079,11 +1014,11 @@
 
         if all_match('d.production\.date\.end', '.*\S.*')
 
-            prepend('d.production\.date\.end', 'vkcdate')
+            prepend('d.production\.date\.end', '#date#')
 
             if all_match('d.production\.date\.end\.prec', '.*\S.*')
 
-                prepend('d.production\.date\.end\.prec', 'vkcprec')
+                prepend('d.production\.date\.end\.prec', '#prec#')
                 paste('d.production\.date\.end','d.production\.date\.end','d.production\.date\.end\.prec',join_char:"")
 
             end
@@ -1097,11 +1032,11 @@
     if all_match(or_record.earliest_dates.0, '.*\S.*')
 
         sort_field(or_record.earliest_dates)
-        if any_match(or_record.earliest_dates.0, 'vkcdate(.*)vkcprec(.*)')
-            parse_text(or_record.earliest_dates.0, 'vkcdate(.*)vkcprec(.*)')
+        if any_match(or_record.earliest_dates.0, '#date#(.*)#prec#(.*)')
+            parse_text(or_record.earliest_dates.0, '#date#(.*)#prec#(.*)')
         else
-            if any_match(or_record.earliest_dates.0, 'vkcdate(.*)')
-                parse_text(or_record.earliest_dates.0, 'vkcdate(.*)')
+            if any_match(or_record.earliest_dates.0, '#date#(.*)')
+                parse_text(or_record.earliest_dates.0, '#date#(.*)')
             end
         end
 
@@ -1110,11 +1045,11 @@
     if all_match(or_record.latest_dates.0, '.*\S.*')
 
         sort_field(or_record.latest_dates, reverse:1)
-        if any_match(or_record.latest_dates.0, 'vkcdate(.*)vkcprec(.*)')
-            parse_text(or_record.latest_dates.0, 'vkcdate(.*)vkcprec(.*)')
+        if any_match(or_record.latest_dates.0, '#date#(.*)#prec#(.*)')
+            parse_text(or_record.latest_dates.0, '#date#(.*)#prec#(.*)')
         else
-            if any_match(or_record.latest_dates.0, 'vkcdate(.*)')
-                parse_text(or_record.latest_dates.0, 'vkcdate(.*)')
+            if any_match(or_record.latest_dates.0, '#date#(.*)')
+                parse_text(or_record.latest_dates.0, '#date#(.*)')
             end
         end
 
@@ -1122,23 +1057,72 @@
 
     if all_match(or_record.earliest_dates.0.0, '.*\S.*')
 
-        if all_match(or_record.latest_dates.0.0, '.*\S.*')
+        if all_match(or_record.earliest_dates.0.1, '.*\S.*')
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -earliest_date: or_record.earliest_dates.0.0,
-                -earliest_date_type: or_record.earliest_dates.0.1,
-                -latest_date: or_record.latest_dates.0.0,
-                -latest_date_type: or_record.latest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.0, '.*\S.*')
+
+                if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -earliest_date_type: or_record.earliest_dates.0.1,
+                        -latest_date: or_record.latest_dates.0.0,
+                        -latest_date_type: or_record.latest_dates.0.1
+                    )
+
+                else
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -earliest_date_type: or_record.earliest_dates.0.1,
+                        -latest_date: or_record.latest_dates.0.0
+                    )
+
+                end
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -earliest_date: or_record.earliest_dates.0.0,
+                    -earliest_date_type: or_record.earliest_dates.0.1
+                )
+
+            end
 
         else
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -earliest_date: or_record.earliest_dates.0.0,
-                -earliest_date_type: or_record.earliest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.0, '.*\S.*')
+
+                if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -latest_date: or_record.latest_dates.0.0,
+                        -latest_date_type: or_record.latest_dates.0.1
+                    )
+
+                else
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -latest_date: or_record.latest_dates.0.0
+                    )
+
+                end
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -earliest_date: or_record.earliest_dates.0.0,
+                )
+
+            end
 
         end
 
@@ -1146,11 +1130,22 @@
 
         if all_match(or_record.latest_dates.0.0, '.*\S.*')
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -latest_date: or_record.latest_dates.0.0,
-                -latest_date_type: or_record.latest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -latest_date: or_record.latest_dates.0.0,
+                    -latest_date_type: or_record.latest_dates.0.1
+                )
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -latest_date: or_record.latest_dates.0.0
+                )
+
+            end
 
         else
 
@@ -1172,13 +1167,13 @@
 
 # LIDO periodName [eventType/term="production"]
 
-    unless is_array(or_record.production_period)
+    unless is_array(or_record.production_period) 
         move_field(or_record.production_period, or_record.tmp)
         set_array(or_record.production_period)
         move_field(or_record.tmp, or_record.production_period.$append)
     end
 
-    unless is_array(or_record.production_period_id)
+    unless is_array(or_record.production_period_id) 
         move_field(or_record.production_period_id, or_record.tmp)
         set_array(or_record.production_period_id)
         move_field(or_record.tmp, or_record.production_period_id.$append)
@@ -1188,18 +1183,18 @@
         copy_field(c, or_record.production_period.$append.id)
     end
 
-    assoc(or_record.period, or_record.production_period.*.value, or_record.production_period.*.id)
+    assoc(or_record.period, or_record.production_period.*.id, or_record.production_period.*)
 
     do each (path: or_record.period, var: c)
 
-        if all_match(c.key, '.*\S.*')
+        if all_match(c.value, '.*\S.*')
 
-            if all_match(c.value, '.*\S.*')
+            if all_match(c.key, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.periodName.$append,
-                    c.key,
-                    -conceptid: c.value,
+                    c.value,
+                    -conceptid: c.key,
                     -lang: nl,
                     -source: Adlib,
                     -type: local
@@ -1209,7 +1204,7 @@
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.periodName.$append,
-                    c.key,
+                    c.value,
                     -lang: nl
                 )
 
@@ -1221,13 +1216,19 @@
 
 # LIDO namePlaceSet [eventType/term="production"]
 
+    unless is_array(or_record.production)
+        move_field(or_record.production, or_record.tmp)
+        set_array(or_record.production)
+        move_field(or_record.tmp, or_record.production.$append)
+    end
+
     do list (path: or_record.production, var: c)
 
-        if all_match('c.production\.place.value', '.*\S.*')
+        if all_match('c.production\.place', '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventPlace.$append.place.namePlaceSet,
-                'c.production\.place.value',
+                'c.production\.place',
                 -value_pref: preferred,
                 -value_lang: nl
             )
@@ -1249,25 +1250,27 @@
 
 # LIDO termMaterialsTech [eventType/term="production"]
 
-    unless is_array(or_record.materials)
+    unless is_array(or_record.materials) 
         move_field(or_record.materials, or_record.tmp)
         set_array(or_record.materials)
         move_field(or_record.tmp, or_record.materials.$append)
     end
 
-    # We'll have multiple termMaterialsTechs: the corresponding value in AAT (type:alternate) and the value from the Adlib field object_name itself (type:preferred)
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from the Adlib field object_name itself (type:preferred)
 
     do list(path: or_record.materials, var: c)
 
         # Value in Adlib
 
-        if all_match(c.material.value, '.*\S.*')
+        if all_match(c.material, '.*\S.*')
+
+            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append.type, "material")
 
             if all_match('c.material\.lref', '.*\S.*')
 
                 lido_term(
-                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append,
-                    c.material.value,
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+                    c.material,
                     -conceptid: 'c.material\.lref',
                     -type: local,
                     -source: Adlib,
@@ -1278,8 +1281,8 @@
             else
 
                 lido_term(
-                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append,
-                    c.material.value,
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+                    c.material,
                     -pref: preferred,
                     -lang: nl
                 )
@@ -1290,18 +1293,18 @@
 
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.material.value, c.aat)
+        copy_field(c.material, c.material_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.material_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat._id, '.*\S.*')
+        if all_match(c.material_aat._id, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.material_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.material_aat.aatterm,
+                    -conceptid: c.material_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -1312,7 +1315,7 @@
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
-                    c.aat.aatterm,
+                    c.material_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
@@ -1325,12 +1328,12 @@
 
 # LIDO displayMaterialsTech [eventType/term="production"]
 
-    unless is_array(or_record.physical_description) 
+    unless is_array(or_record.physical_description)
         move_field(or_record.physical_description, or_record.tmp)
         set_array(or_record.physical_description)
         move_field(or_record.tmp, or_record.physical_description.$append)
     end
-
+    
     do list(path: or_record.physical_description, var: c)
 
         if all_match(c, '.*\S.*')
@@ -1349,7 +1352,99 @@
 
 # LIDO subjectConcept / subjectEvent / subjectPlace
 
-    unless is_array(or_record.depicted_subject)
+    # Content motif general
+
+    unless is_array(or_record.content_motif_general)
+        move_field(or_record.content_motif_general, or_record.tmp)
+        set_array(or_record.content_motif_general)
+        move_field(or_record.tmp, or_record.content_motif_general.$append)
+    end
+
+    unless is_array(or_record.content_motif_general_id)
+        move_field(or_record.content_motif_general_id, or_record.tmp)
+        set_array(or_record.content_motif_general_id)
+        move_field(or_record.tmp, or_record.content_motif_general_id.$append)
+    end
+
+    do list(path:or_record.content_motif_general_id, var:c)
+        copy_field(c, or_record.content_motif_general.$append.id)
+    end
+
+    assoc(or_record.general_motif, or_record.content_motif_general.*.id, or_record.content_motif_general.*)
+
+    # We'll have multiple terms for the type "content-motif-general": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+
+    do each(path:or_record.general_motif, var:c)
+
+        # Value in Adlib
+
+        if all_match(c.value, '.*\S.*')
+
+            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "content-motif-general")
+
+            if all_match(c.key, '.*\S.*')
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+                    c.value,
+                    -conceptid: c.key,
+                    -type: local,
+                    -source: Adlib,
+                    -pref: preferred,
+                    -lang: nl
+                )
+
+            else
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+                    c.value,
+                    -pref: preferred,
+                    -lang: nl
+                )
+
+            end
+
+        end
+
+        # Corresponding value in AAT, not (yet) retrievable via API
+
+        copy_field(c.value, c.general_motif_aat)
+
+        lookup_in_store(c.general_motif_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+
+        if all_match(c.general_motif_aat.aatterm, '.*\S.*')
+
+            if all_match(c.general_motif_aat.aaturi, '.*\S.*')
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$last,
+                    c.general_motif_aat.aatterm,
+                    -conceptid: c.general_motif_aat.aaturi,
+                    -type: purl,
+                    -source: AAT,
+                    -pref: alternate,
+                    -lang: nl
+                )
+
+            else
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$last,
+                    c.general_motif_aat.aatterm,
+                    -pref: alternate,
+                    -lang: nl
+                )
+
+            end
+
+        end
+
+    end
+
+    # Depicted subject
+
+    unless is_array(or_record.depicted_subject) 
         move_field(or_record.depicted_subject, or_record.tmp)
         set_array(or_record.depicted_subject)
         move_field(or_record.tmp, or_record.depicted_subject.$append)
@@ -1357,15 +1452,13 @@
 
     do list(path:or_record.depicted_subject, var:c)
 
-        if all_match('c.content\.subject.value', '.*\S.*')
+        if all_match('c.content\.subject', '.*\S.*')
 
             if all_match('c.content\.subject\.type.value.2.content', 'geografie')
 
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectPlace.$append)
-
                 lido_basenameset(
-                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectPlace.$last.place.namePlaceSet,
-                    'c.content\.subject.value'
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectPlace.$append.place.namePlaceSet,
+                    'c.content\.subject'
                 )
 
                 if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1383,13 +1476,11 @@
 
                 if all_match('c.content\.subject\.type.value.2.content', 'gebeurtenis')
 
-                    add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$append)
-
                     set_field(or_record.event_type, event)
                     set_field(or_record.event_type_URI, 'http://www.cidoc-crm.org/Entity/e5-event/version-6.2')
 
                     lido_term(
-                        descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventType,
+                        descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectEvent.$append.event.eventType,
                         or_record.event_type,
                         -conceptid: or_record.event_type_URI,
                         -type: purl,
@@ -1398,7 +1489,7 @@
 
                     lido_basenameset(
                         descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventName,
-                        'c.content\.subject.value'
+                        'c.content\.subject'
                     )
 
                     if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1416,13 +1507,11 @@
 
                     if all_match('c.content\.subject\.type.value.2.content', 'activiteit')
 
-                        add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$append)
-
                         set_field(or_record.event_type, activity)
                         set_field(or_record.event_type_URI, 'http://www.cidoc-crm.org/Entity/e7-activity/version-6.2')
 
                         lido_term(
-                            descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventType,
+                            descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectEvent.$append.event.eventType,
                             or_record.event_type,
                             -conceptid: or_record.event_type_URI,
                             -type: purl,
@@ -1431,7 +1520,7 @@
 
                         lido_basenameset(
                             descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventName,
-                            'c.content\.subject.value'
+                            'c.content\.subject'
                         )
 
                         if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1450,8 +1539,8 @@
                         if all_match('c.content\.subject\.lref', '.*\S.*')
 
                             lido_term(
-                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
-                                'c.content\.subject.value',
+                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectConcept.$append,
+                                'c.content\.subject',
                                 -conceptid: 'c.content\.subject\.lref',
                                 -type: local,
                                 -source: Adlib
@@ -1460,8 +1549,8 @@
                         else
 
                             lido_term(
-                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
-                                'c.content\.subject.value'
+                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectConcept.$append,
+                                'c.content\.subject'
                             )
 
                         end
@@ -1478,7 +1567,7 @@
 
 # LIDO subjectActor
 
-    unless is_array(or_record.depicted_person)
+    unless is_array(or_record.depicted_person) 
         move_field(or_record.depicted_person, or_record.tmp)
         set_array(or_record.depicted_person)
         move_field(or_record.tmp, or_record.depicted_person.$append)
@@ -1486,19 +1575,21 @@
 
     do list(path:or_record.depicted_person, var:c)
 
-        if all_match('c.content\.person\.name.value', '.*\S.*')
+        if all_match('c.content\.person\.name', '.*\S.*')
 
-            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$append)
-
-            copy_field('c.content\.person\.name.value', descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.nameActorSet.appellationValue._)
+            lido_basenameset(
+                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectActor.$append.actor.nameActorSet,
+                'c.content\.person\.name'
+            )
 
             if all_match('c.content\.person\.name\.lref', '.*\S.*')
 
-                copy_field('c.content\.person\.name\.lref', descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID._)
-
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID.type, "local")
-
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID.source, "Adlib")
+                lido_baseid(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID,
+                    'c.content\.person\.name\.lref',
+                    -type: local,
+                    -source: Adlib
+                )
 
             end
 
@@ -1510,13 +1601,33 @@
 
 ### LIDO administrativeMetadata
 
+## LIDO rightsWorkWrap
+
+# LIDO creditLine
+
+    do list(path: or_record.object_number, var: c)
+
+        lookup_in_store(c, DBI, data_source: 'dbi:SQLite:/tmp/import.RIGHTS.sqlite')
+
+        if all_match(c.rights, '.*\S.*')
+
+            lido_basevalue(
+                administrativeMetadata.rightsWorkWrap.rightsWorkSet.creditLine,
+                c.rights
+            )
+
+        end
+
+    end
+
+
 ## LIDO recordWrap
 
 # LIDO recordID
 
 #    do list(path:or_record.pids, var: c)
 
-#        if all_match('c.digital_reference\.description.value', 'datapid')
+#        if all_match('c.digital_reference\.description', 'datapid')
 
 #            if all_match(c.digital_reference, '.*\S.*')
 
@@ -1597,11 +1708,11 @@
 
     do list(path: or_record.institution, var: c)
 
-        if all_match(c.value, '.*\S.*')
+        if all_match(c, '.*\S.*')
 
             lido_basenameset(
-                administrativeMetadata.recordWrap.recordSource.legalBodyName.$append,
-                c.value
+                administrativeMetadata.recordWrap.recordSource.legalBodyName,
+                c
             )
 
         end
@@ -1622,12 +1733,13 @@
 
 #    do list(path:or_record.pids, var: c)
 
-#        if all_match('c.digital_reference\.description.value', 'representationpid')
+#        if all_match('c.digital_reference\.description', 'representationpid')
 
 #            if all_match(c.digital_reference, '.*\S.*')
 
 #                copy_field(c.digital_reference, administrativeMetadata.resourceWrap.resourceSet.resourceID._)
 #                add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.type, "purl")
+#                add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.label, "representationPID")
 
 #                copy_field(c.digital_reference, administrativeMetadata.resourceWrap.resourceSet.resourceRepresentation.linkResource._)
 
@@ -1645,9 +1757,10 @@
 
         copy_field(or_record.identificator.representationPid, administrativeMetadata.resourceWrap.resourceSet.resourceID._)
         add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.type, "purl")
+        add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.label, "representationPID")
 
         copy_field(or_record.identificator.representationPid, administrativeMetadata.resourceWrap.resourceSet.resourceRepresentation.linkResource._)
-        
+
     end
 
 

--- a/muzee_oai_adlib.fix
+++ b/muzee_oai_adlib.fix
@@ -2,7 +2,7 @@
 #
 # Institution: Mu.ZEE Ostend
 # Description: Converts Adlib Structured XML exposed via ErfgoedInzicht OAI to LIDO 1.0
-# Created: 9/1/2019
+# Created: 9/4/2020
 
 
 
@@ -15,36 +15,58 @@
     copy_field(_metadata.Object_name, or_record.object_name)
     copy_field(_metadata.object_category, or_record.object_category)
     copy_field('_metadata.object_category\.lref', or_record.object_category_id)
-    copy_field('_metadata.content\.motif\.general', or_record.subject)
-    copy_field('_metadata.content\.motif\.general\.lref', or_record.subject_id)
     copy_field(_metadata.Title, or_record.title)
     copy_field(_metadata.Titel_translation, or_record.title_translation)
     copy_field('_metadata.institution\.name', or_record.institution)
     copy_field(_metadata.object_number, or_record.object_number)
+#    copy_field(_metadata.print_state, or_record.print_state)
+#    copy_field(_metadata.copy_number, or_record.copy_number)
+#    copy_field(_metadata.edition, or_record.edition)
     copy_field(_metadata.Description, or_record.description)
+#    copy_field(_metadata.part, or_record.part)
+#    copy_field(_metadata.number_of_parts, or_record.number_of_parts)
     copy_field(_metadata.Dimension, or_record.dimensions)
+    copy_field('_metadata.dimension\.free', or_record.displaydimension)
+#    copy_field(_metadata.Inscription, or_record.inscription)
+#    copy_field(_metadata.Current_location, or_record.current_location)
+#    copy_field(_metadata.Acquisition_source, or_record.acquisition_source)
+#    copy_field('_metadata.acquisition\.date', or_record.acquisition_date)
 #    copy_field('_metadata.acquisition\.method', or_record.acquisition_method)
 #    copy_field('_metadata.acquisition\.method\.lref', or_record.acquisition_method_id)
-#    copy_field('_metadata.Acquisition_source.acquisition\.source.value', or_record.acquisition_source)
-#    copy_field('_metadata.acquisition\.date', or_record.acquisition_date)
+#    copy_field(_metadata.credit_line, or_record.acquisition_creditline)
+#    copy_field(_metadata.Exhibition, or_record.exhibition)
     copy_field(_metadata.Production, or_record.production)
     copy_field(_metadata.Production_date, or_record.production_date)
     copy_field('_metadata.production\.period', or_record.production_period)
     copy_field('_metadata.production\.period\.lref', or_record.production_period_id)
     copy_field(_metadata.Material, or_record.materials)
-    copy_field(_metadata.physical_description, or_record.physical_description)
-    copy_field(_metadata.Content_person, or_record.depicted_person)
+    copy_field(_metadata.material_description, or_record.physical_description)
+#    copy_field(_metadata.Technique, or_record.technique)
+#    copy_field(_metadata.current_owner, or_record.current_owner)
+    copy_field('_metadata.content\.motif\.general', or_record.content_motif_general)
+    copy_field('_metadata.content\.motif\.general\.lref', or_record.content_motif_general_id)
+#    copy_field('_metadata.content\.motif\.specific', or_record.content_motif_specific)
+#    copy_field('_metadata.content\.motif\.specific\.lref', or_record.content_motif_specific_id)
     copy_field(_metadata.Content_subject, or_record.depicted_subject)
+#    copy_field(_metadata.Associated_subject, or_record.associated_subject)
+    copy_field(_metadata.Content_person, or_record.depicted_person)
+#    copy_field(_metadata.Associated_person, or_record.associated_person)
+#    copy_field('_metadata.content\.date\.period', or_record.depicted_period)
+#    copy_field(_metadata.Associated_period, or_record.associated_period)
     copy_field(_metadata.priref, or_record.priref)
-    copy_field('_metadata.dimension\.free', or_record.displaydimension)  
+#    copy_field(_metadata.Rights, or_record.rights)
 
+    
+ 
 # Remove all Adlib fields, retaining only the fields to create the lido structure
 
     retain(or_record)
 
- ### Mapping to lido structure
 
- # Mapping Facets
+
+### Mapping to lido structure
+
+# Mapping Facets
 # --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # Adlib                                             LIDO                                                VKC                     Invulboek veld
 #                                                       lido:lidoRecID
@@ -60,38 +82,49 @@
 #   Object_name.object_name                                     pref: preferred                             Subtype                 term objectnaam
 #                                                               pref: alternate                             Subtype
 #                                                       lido:classification
-#                                                           type: objectcategorie
+#                                                           type: object-category
 #                                                               lido:conceptID
 #   object_category.\lref                                           pref: preferred
 #                                                                   pref: alternate                                                 identificatie
 #                                                               lido:term
 #   object_category                                                 pref: preferred                         Type                    term
 #                                                                   pref: alternate                         Type
-#                                                           type: hoofdmotief
-#                                                               lido:conceptID
-#   content\.motif\.general\.lref                                   pref: preferred
-#                                                                   pref: alternate                                                 identificatie hoofdmotief
-#                                                               lido:term
-#   content\.motif\.general                                         pref: preferred                         Onderwerp               term hoofdmotief
-#                                                                   pref: alternate                         Onderwerp
 #                                                       lido:titleSet
 #   Title                                                   pref: preferred                                                         titel
 #   Titel_translation                                       pref: alternate
-#   institution\.name.value                             lido:repositoryName                                 Instelling              naam bewaarinstelling
-#                                                       lido:workID
-#   object_number                                           type: objectnummer                              Inventarisnummer        waarde objectnummer
-#   Description                                         lido:objectDescriptionSet                           Beschrijving            korte beschrijving
+#                                                       lido:inscriptions
+#   Inscription.inscription\.content                        lido:inscriptionTranscription
+#                                                           lido:inscriptionDescription
+#   Inscription.inscription\.type                               type: type
+#   Inscription.inscription\.position                           type: position
+#                                                       lido:repositorySet
+#   institution\.name                                       lido:repositoryName                             Instelling              naam bewaarinstelling
+#                                                           lido:workID
+#   object_number                                               type: object-number                         Inventarisnummer        waarde objectnummer
+#   Current_location.current_location                       lido:repositoryLocation
+#                                                       lido:displayStateEditionWrap
+#   print_state                                             lido:displayState
+#                                                           lido:displayEdition
+#   copy_number                                                 label: copy-number
+#   edition                                                     label: edition
+#                                                       lido:objectDescriptionSet
+#   Description                                             no type                                         Beschrijving            korte beschrijving
+#   part                                                    type: part
+#   number_of_parts                                         type: number-of-parts
 #                                                       lido:objectMeasurementsSet
-#   dimension\.free                                         lido:displayObjectMeasurements                  Dimensies               Mu.Zee zet dimensies in dimension.free als string
+#   dimension\.free                                         lido:displayObjectMeasurements                  Dimensies
 #                                                           lido:objectMeasurements
 #                                                               lido:measurementsSet
-#   Dimension.dimension\.type.value                                 lido:measurementType                                            dimensie afmeting
-#   Dimension.dimension\.unit.value                                 lido:measurementUnit                                            eenheid afmeting
+#   Dimension.dimension\.type                                       lido:measurementType                                            dimensie afmeting
+#   Dimension.dimension\.unit                                       lido:measurementUnit                                            eenheid afmeting
 #   Dimension.dimension\.value                                      lido:measurementValue                                           waarde afmeting
-#   Dimension.dimension\.part                               lido:extentMeasurements                                                 onderdeel afmeting
+#   Dimension.dimension\.part                                   lido:extentMeasurements                                             onderdeel afmeting
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               acquisition
+#   Acquisition_source.acquisition\.source                          lido:eventActor                                                 naam verwervingsbron
+#                                                                   lido:eventDate
+#   acquisition\.date                                                   lido:displayDate                                            waarde verwervingdatum
 #                                                                   lido:eventMethod
 #                                                                       lido:conceptID
 #   acquisition\.method\.lref                                               pref: preferred
@@ -99,10 +132,14 @@
 #                                                                       lido:term
 #   acquisition\.method                                                     pref: preferred                                         term verwervingsmethode
 #                                                                           pref: alternate
-#                                                                   lido:eventActor
-#   Acquisition_source                                                  lido:nameActorSet                                           naam verwervingsbron
+#   credit_line                                                     lido:eventDescriptionSet
+#                                                       lido:eventType
+#                                                           lido:term
+#                                                               exhibition
+#   Exhibition.exhibition                                           lido:eventName
 #                                                                   lido:eventDate
-#   acquisition\.date                                                   lido:displayDate                                            waarde verwervingdatum
+#   Exhibition.exhibition\.date\.start                                  lido:earliestDate
+#   Exhibition.exhibition\.date\.end                                    lido:latestDate
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               production
@@ -110,13 +147,13 @@
 #                                                                       lido:actorID
 #   Production.creator\.lref                                                type: local
 #                                                                           type: purl                                              identificatie vervaardiger
-#   Production.creator.value                                            lido:nameActorSet
+#   Production.creator                                                  lido:nameActorSet
 #                                                                           pref: preferred                 Vervaardiger            naam vervaardiger
 #                                                                           pref: alternate
 #                                                                       lido:vitalDatesActor
 #   Production.creator\.date_of_birth                                       lido:earliestDate
 #   Production.creator\.date_of_death                                       lido:latestDate
-#   Production.creator\.role.value                                      lido:roleActor                      Vervaardiger            rol vervaardiger
+#   Production.creator\.role                                            lido:roleActor                      Vervaardiger            rol vervaardiger
 #   Production.creator\.qualifier                                       lido:attributionQualifierActor      Vervaardiger            kwalificatie vervaardiger
 #                                                                   lido:eventDate
 #                                                                       lido:displayDate                    Datering
@@ -131,16 +168,25 @@
 #                                                                       lido:placeID
 #   Production.production\.place\.lref                                      type: local
 #                                                                       lido:namePlaceSet
-#   Production.production\.place.value                                      type: preferred
+#   Production.production\.place                                            type: preferred
 #                                                                   lido:termMaterialsTech
-#                                                                       lido:conceptID
-#    Material.material\.notes                                              pref: preferred                                          Mu.Zee zet volzinnen met materiaaltechnische beschrijving in material.notes, dit zou beter gebruikt worden dan de lref.
-#    Material.material\.lref                                               pref: alternate                                         identificatie materiaal.  
-#    Material.material\.notes                                       lido: sourceMaterialsTech                                       Binnen de materials notes zet Mu.Zee de bron van de beschrijving tussen haakjes. Dit zou geëxtraheerd kunnen worden en in dit veld gestoken worden. Geen idee hoe consistent dit tussen haakjes wordt gezet.                                     
-#                                                                       lido:term
-#   Material.material.value                                                 pref: preferred                                         term materiaal
-#                                                                           pref: alternate
-#   material_description                                            lido:displayMaterialsTech               Materiaal
+#                                                                       type: material
+#                                                                           lido:conceptID
+#   Material.material\.lref                                                     pref: preferred
+#                                                                               pref: alternate                                     identificatie materiaal
+#                                                                           lido:term
+#   Material.material                                                           pref: preferred             Materiaal               term materiaal
+#                                                                               pref: alternate
+#                                                                       type: technique
+#                                                                           lido:conceptID
+#   Technique.technique\.lref                                                   pref: preferred
+#                                                                           lido:term
+#   Technique.technique                                                         pref: preferred
+#   material_description                                            lido:displayMaterialsTech
+#                                                       lido:eventType
+#                                                           lido:term
+#                                                               provenance
+#   current_owner                                                   lido:eventActor
 #                                                       lido:eventType
 #                                                           lido:term
 #                                                               check
@@ -149,21 +195,49 @@
 #                                                                       lido:nameActorSet                                           assessor conditie
 #                                                                   lido:eventDate
 #                                                                       lido:displayDate                                            datum conditie
-#                                                       lido:subject
-#                                                           lido:type
-#                                                               lido:subjectConcept
-#   Content_subject.content\.subject\.lref                          lido:conceptID                                                  identificatie afgebeeld concept
-#   Content_subject.content\.subject.value                          lido:term                                                       term afgebeeld concept
-#                                                               lido:subjectPlace
-#   Content_subject.content\.subject\.lref                          lido:placeID                                                    identificatie afgebeelde locatie
-#   Content_subject.content\.subject.value                          lido:namePlaceSet                                               naam afgebeelde locatie
-#                                                               lido:subjectActor
-#   Content_person.content\.person\.name\.lref                      lido:actorID                                                    identificatie afgebeelde persoon of instelling
-#   Content_person.content\.person\.name.value                      lido:nameActorSet                                               naam afgebeelde persoon of instelling
+#                                                       lido:objectRelationWrap
+#                                                           lido:subject
+#                                                               type: content-motif-general
+#                                                                   lido:subjectConcept
+#                                                                       lido:conceptID
+#   content\.motif\.general\.lref                                           pref: preferred
+#                                                                           pref: alternate                                         identificatie hoofdmotief
+#                                                                       lido:term
+#   content\.motif\.general                                                 pref: preferred                 Onderwerp               term hoofdmotief
+#                                                                           pref: alternate                 Onderwerp
+#                                                               type: content-motif-specific
+#                                                                   lido:subjectConcept
+#                                                                       lido:conceptID
+#   content\.motif\.specific\.lref                                          pref: preferred
+#                                                                       lido:term
+#   content\.motif\.specific                                                pref: preferred
+#                                                               no type
+#                                                                   lido:subjectConcept
+#   Content_subject.content\.subject\.lref                              lido:conceptID                                              identificatie afgebeeld concept
+#   Content_subject.content\.subject                                    lido:term                                                   term afgebeeld concept
+#                                                                   lido:subjectActor
+#   Content_person.content\.person\.name\.lref                          lido:actorID                                                identificatie afgebeelde persoon of instelling
+#   Content_person.content\.person\.name                                lido:nameActorSet                                           naam afgebeelde persoon of instelling
+#                                                                   lido:subjectDate
+#   content\.date\.period                                               lido:displayDate
+#                                                                   lido:subjectEvent
+#   Content_subject.content\.subject\.lref                              lido:eventID                                                identificatie afgebeelde gebeurtenis
+#   Content_subject.content\.subject                                    lido:eventName                                              naam afgebeelde gebeurtenis
+#                                                                   lido:subjectPlace
+#   Content_subject.content\.subject\.lref                              lido:placeID                                                identificatie afgebeelde locatie
+#   Content_subject.content\.subject                                    lido:namePlaceSet                                           naam afgebeelde locatie
+#                                                               type: associated
+#                                                                   lido:subjectConcept
+#   Associated_subject.association\.subject                             lido:term
+#                                                                   lido:subjectActor
+#   Associated_person.association\.person                               lido:nameActorSet
+#                                                                   lido:subjectDate
+#   Associated_period.association\.period                               lido:displayDate
 #                                                       lido:rightsWorkWrap
 #                                                           lido:rightsType
 #                                                               lido:conceptID                                                      identificatie rechten werk
 #                                                               lido:term                                                           term rechten werk
+#   Rights.rights\.notes                                    lido:creditLine
 #                                                       lido:recordWrap
 #                                                           lido:recordID
 #   Digital_reference.digital_reference                         type: global                                Data PURL               waarde databanknummer
@@ -173,7 +247,7 @@
 #                                                               lido:term
 #                                                           lido:recordSource
 #                                                               lido:legalBodyID                                                    identificatie data provider
-#   institution\.name.value                                     lido:legalBodyName                                                  naam data provider
+#   institution\.name                                           lido:legalBodyName                                                  naam data provider
 #                                                               lido:legalBodyWeblink
 #                                                           lido:recordRights
 #                                                               lido:rightsType
@@ -185,7 +259,7 @@
 
 
 
- ### LIDO lidoRecID
+### LIDO lidoRecID
 
     # ID
     #
@@ -194,7 +268,7 @@
     # the ID field looks like this:
     #
     #   oai:datahub.vlaamsekunstcollectie.be:<domain>:<identifier>
-    #   ex. oai:datahub.vlaamsekunstcollectie.be:kmska.be:254
+    #   ex. oai:datahub.vlaamsekunstcollectie.be:muzee.be:254
     #   ex. oai:datahub.vlaamsekunstcollectie.be:collectievlaamsegemeenschap.be:837
     #
     # Note: the .tld is stripped from the domainname because the . (dot) breaks the
@@ -208,7 +282,7 @@
 
     do list(path:or_record.pids, var: c)
 
-        if all_match('c.digital_reference\.description.value', 'datapid')
+        if all_match('c.digital_reference\.description', 'datapid')
 
             if all_match(c.digital_reference, '.*\S.*')
 
@@ -240,7 +314,6 @@
         end
 
     end
-
 
  
 
@@ -303,19 +376,19 @@
         move_field(or_record.tmp, or_record.object_name.$append)
     end
 
-    # We'll have multiple objectWorkTypes: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
 
     do list(path: or_record.object_name, var: c)
 
         # Value in Adlib
 
-        if all_match(c.object_name.value, '.*\S.*')
+        if all_match(c.object_name, '.*\S.*')
 
             if all_match('c.object_name\.lref', '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$append,
-                    c.object_name.value,
+                    c.object_name,
                     -conceptid: 'c.object_name\.lref',
                     -type: local,
                     -source: Adlib,
@@ -327,7 +400,7 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$append,
-                    c.object_name.value,
+                    c.object_name,
                     -pref: preferred,
                     -lang: nl
                 )
@@ -338,18 +411,18 @@
 
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.object_name.value, c.aat)
+        copy_field(c.object_name, c.object_name_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.object_name_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat.aatterm, '.*\S.*')
+        if all_match(c.object_name_aat.aatterm, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.object_name_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.object_name_aat.aatterm,
+                    -conceptid: c.object_name_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -360,7 +433,7 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.objectWorkTypeWrap.objectWorkType.$last,
-                    c.aat.aatterm,
+                    c.object_name_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
@@ -371,7 +444,7 @@
 
     end
 
-# LIDO classification [type="objectcategorie"]
+# LIDO classification [type="object-category"]
 
     unless is_array(or_record.object_category) 
         move_field(or_record.object_category, or_record.tmp)
@@ -389,9 +462,9 @@
         copy_field(c, or_record.object_category.$append.id)
     end
 
-    assoc(or_record.object_cat, or_record.object_category.*.id, or_record.object_category.*.value)
+    assoc(or_record.object_cat, or_record.object_category.*.id, or_record.object_category.*)
 
-    # We'll have multiple classifications with type "objectcategorie": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+    # We'll have multiple terms for the type "object-category": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
 
     do each (path: or_record.object_cat, var: c)
 
@@ -422,24 +495,24 @@
 
             end
 
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "objectcategorie")
+            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "object-category")
 
         end
     
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.value, c.aat)
+        copy_field(c.value, c.object_category_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.object_category_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat.aatterm, '.*\S.*')
+        if all_match(c.object_category_aat.aatterm, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.object_category_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.object_category_aat.aatterm,
+                    -conceptid: c.object_category_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -450,106 +523,14 @@
 
                 lido_term(
                     descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
+                    c.object_category_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
 
             end
 
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "objectcategorie")
-
-        end
-
-    end
-
-# LIDO classification [type="hoofdmotief"]
-
-    unless is_array(or_record.subject) 
-        move_field(or_record.subject, or_record.tmp)
-        set_array(or_record.subject)
-        move_field(or_record.tmp, or_record.subject.$append)
-    end
-
-    unless is_array(or_record.subject_id)
-        move_field(or_record.subject_id, or_record.tmp)
-        set_array(or_record.subject_id)
-        move_field(or_record.tmp, or_record.subject_id.$append)
-    end
-
-    do list (path: or_record.subject_id, var: c)
-        copy_field(c, or_record.subject.$append.id)
-    end
-
-    assoc(or_record.general_motif, or_record.subject.*.id, or_record.subject.*.value)
-
-    # We'll have multiple classifications with type "hoofdmotief": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
-
-    do each(path: or_record.general_motif, var: c)
-
-        # Value in Adlib
-
-        if all_match(c.value, '.*\S.*')
-
-            if all_match(c.key, '.*\S.*')
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$append,
-                    c.value,
-                    -conceptid: c.key,
-                    -type: local,
-                    -source: Adlib,
-                    -pref: preferred,
-                    -lang: nl
-                )
-
-            else
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$append,
-                    c.value,
-                    -pref: preferred,
-                    -lang: nl
-                )
-
-            end
-
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "hoofdmotief")
-
-        end
-    
-        # Corresponding value in AAT, not (yet) retrievable via API
-
-        copy_field(c.value, c.aat)
-
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
-
-        if all_match(c.aat.aatterm, '.*\S.*')
-
-            if all_match(c.aat.aaturi, '.*\S.*')
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
-                    -type: purl,
-                    -source: AAT,
-                    -pref: alternate,
-                    -lang: nl
-                )
-
-            else
-
-                lido_term(
-                    descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last,
-                    c.aat.aatterm,
-                    -pref: alternate,
-                    -lang: nl
-                )
-
-            end
-
-            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "hoofdmotief")
+            add_field(descriptiveMetadata.objectClassificationWrap.classificationWrap.classification.$last.type, "object-category")
 
         end
 
@@ -568,11 +549,11 @@
 
     do list(path: or_record.title, var: c)
 
-        if all_match(c.title.value, '.*\S.*')
+        if all_match(c.title, '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.objectIdentificationWrap.titleWrap.titleSet.$append,
-                c.title.value,
+                c.title,
                 -value_pref: preferred
             )
 
@@ -610,11 +591,11 @@
 
     do list(path: or_record.institution, var: c)
 
-        if all_match(c.value, '.*\S.*')
+        if all_match(c, '.*\S.*')
 
             lido_basenameset(
-                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.repositoryName.legalBodyName.$append,
-                c.value
+                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$append.repositoryName.legalBodyName,
+                c
             )
 
         end
@@ -634,16 +615,106 @@
         if all_match(c, '.*\S.*')
 
             lido_baseid(
-                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.workID,
+                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$last.workID,
                 c,
-                -type: objectnummer
+                -type: object-number
             )
 
         end
 
     end
 
+# LIDO repositoryLocation
+
+#    unless is_array(or_record.current_location) 
+#        move_field(or_record.current_location, or_record.tmp)
+#        set_array(or_record.current_location)
+#        move_field(or_record.tmp, or_record.current_location.$append)
+#    end
+
+#    do list(path: or_record.current_location, var: c)
+
+#        copy_field(c.current_location, c.current_location_lookup)
+
+#        lookup_in_store(c.current_location_lookup, DBI, data_source: "dbi:SQLite:/tmp/import.CURRENT_LOCATIONS_UTF8.sqlite")
+
+#        if all_match(c.current_location_lookup.display_name, '.*\S.*')
+
+#            lido_basenameset(
+#                descriptiveMetadata.objectIdentificationWrap.repositoryWrap.repositorySet.$append.repositoryLocation.namePlaceSet,
+#                c.current_location_lookup.display_name
+#            )
+
+#        end
+
+#    end
+
+# LIDO displayState
+
+#    unless is_array(or_record.print_state)
+#        move_field(or_record.print_state, or_record.tmp)
+#        set_array(or_record.print_state)
+#        move_field(or_record.tmp, or_record.print_state.$append)
+#    end
+
+#    do list(path:or_record.print_state, var: c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_basevalue(
+#                descriptiveMetadata.objectIdentificationWrap.displayStateEditionWrap.displayState,
+#                c
+#            )
+
+#        end
+
+#    end
+
+# LIDO displayEdition
+
+#    unless is_array(or_record.copy_number)
+#        move_field(or_record.copy_number, or_record.tmp)
+#        set_array(or_record.copy_number)
+#        move_field(or_record.tmp, or_record.copy_number.$append)
+#    end
+
+#    do list(path:or_record.copy_number, var: c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_basevalue(
+#                descriptiveMetadata.objectIdentificationWrap.displayStateEditionWrap.displayEdition,
+#                c,
+#                -label: copy-number
+#            )
+
+#        end
+
+#    end
+
+#    unless is_array(or_record.edition)
+#        move_field(or_record.edition, or_record.tmp)
+#        set_array(or_record.edition)
+#        move_field(or_record.tmp, or_record.edition.$append)
+#    end
+
+#    do list(path:or_record.edition, var: c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_basevalue(
+#                descriptiveMetadata.objectIdentificationWrap.displayStateEditionWrap.displayEdition,
+#                c,
+#                -label: edition
+#            )
+
+#        end
+
+#    end
+
 # LIDO objectDescriptionSet
+
+    # Description
 
     unless is_array(or_record.description) 
         move_field(or_record.description, or_record.tmp)
@@ -655,15 +726,64 @@
 
         if all_match(c.description, '.*\S.*')
 
-            copy_field(c.description, descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.$last.descriptiveNoteValue._)
+            lido_descriptivenote(
+                descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet,
+                c.description
+            )
 
         end
 
     end
 
+    # Part
+
+#    unless is_array(or_record.part)
+#        move_field(or_record.part, or_record.tmp)
+#        set_array(or_record.part)
+#        move_field(or_record.tmp, or_record.part.$append)
+#    end
+
+#    do list(path:or_record.part, var: c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_descriptivenote(
+#                descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet,
+#                c
+#            )
+
+#            add_field(descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.$last.type, "part")
+
+#        end
+
+#    end
+
+    # Number of parts
+
+#    unless is_array(or_record.number_of_parts)
+#        move_field(or_record.number_of_parts, or_record.tmp)
+#        set_array(or_record.number_of_parts)
+#        move_field(or_record.tmp, or_record.number_of_parts.$append)
+#    end
+
+#    do list(path:or_record.number_of_parts, var: c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_descriptivenote(
+#                descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet,
+#                c
+#            )
+
+#            add_field(descriptiveMetadata.objectIdentificationWrap.objectDescriptionWrap.objectDescriptionSet.$last.type, "number-of-parts")
+
+#        end
+
+#    end
+
 # LIDO objectMeasurementsWrap
 
-#Take the string out of displaydimension and put it in displayObjectMeasurements in LIDO. 
+    # Take the string out of displaydimension and put it in displayObjectMeasurements in LIDO
     
     unless is_array(or_record.displaydimension) 
         move_field(or_record.displaydimension, or_record.tmp)
@@ -673,34 +793,37 @@
 
     do list(path:or_record.displaydimension, var:c)
 
-        add_field(descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$append)
-
         if all_match('c', '.*\S.*')
+
+            add_field(descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$append)
+
             copy_field('c', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.displayObjectMeasurements._)
+
         end
+
     end
 
-# Generate height, width, depth using the dimensions type, unit, and part params
+    # Generate height, width, depth using the dimensions type, unit, and part params
 
-  unless is_array(or_record.dimensions) 
+    unless is_array(or_record.dimensions)
         move_field(or_record.dimensions, or_record.tmp)
         set_array(or_record.dimensions)
-       move_field(or_record.tmp, or_record.dimensions.$append)
+        move_field(or_record.tmp, or_record.dimensions.$append)
     end
 
     do list(path:or_record.dimensions, var:c)
         
         add_field(descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$append)
 
-        if all_match('c.dimension\.type.value', '.*\S.*')
+        if all_match('c.dimension\.type', '.*\S.*')
 
-            copy_field('c.dimension\.type.value', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementType._)
+            copy_field('c.dimension\.type', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementType._)
 
         end
 
-        if all_match('c.dimension\.unit.value', '.*\S.*')
+        if all_match('c.dimension\.unit', '.*\S.*')
 
-            copy_field('c.dimension\.unit.value', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementUnit._)
+            copy_field('c.dimension\.unit', descriptiveMetadata.objectIdentificationWrap.objectMeasurementsWrap.objectMeasurementsSet.$last.objectMeasurements.measurementsSet.measurementUnit._)
 
         end
 
@@ -718,97 +841,78 @@
 
     end
 
+# LIDO inscriptions
+
+#    unless is_array(or_record.inscription) 
+#        move_field(or_record.inscription, or_record.tmp)
+#        set_array(or_record.inscription)
+#        move_field(or_record.tmp, or_record.inscription.$append)
+#    end
+
+#    do list(path:or_record.inscription, var:c)
+
+#        if all_match('c.inscription\.content', '.*\S.*')
+        
+#            add_field(descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$append)
+
+#        else
+
+#            if all_match('c.inscription\.type', '.*\S.*')
+
+#                add_field(descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$append)
+
+#            else
+
+#                if all_match('c.inscription\.position', '.*\S.*')
+
+#                    add_field(descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$append)
+
+#                end
+
+#            end
+
+#        end
+
+
+#        if all_match('c.inscription\.content', '.*\S.*')
+
+#            copy_field('c.inscription\.content', descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$last.inscriptionTranscription._)
+
+#        end
+
+#        if all_match('c.inscription\.type', '.*\S.*')
+
+#            copy_field('c.inscription\.type', descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$last.inscriptionDescription.$append.descriptiveNoteValue._)
+
+#            add_field(descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$last.inscriptionDescription.$last.type, "type")
+
+#        end
+
+#        if all_match('c.inscription\.position', '.*\S.*')
+
+#            copy_field('c.inscription\.position', descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$last.inscriptionDescription.$append.descriptiveNoteValue._)
+
+#            add_field(descriptiveMetadata.objectIdentificationWrap.inscriptionsWrap.inscriptions.$last.inscriptionDescription.$last.type, "position")
+
+#        end
+
+#    end
+
 
 ## LIDO eventWrap
 
 # LIDO eventType [eventType/term="acquisition"]
 
-#    add_field(or_record.event_type, acquisition)
+#    add_field(or_record.event_type, "acquisition")
 
 #    lido_term(
 #        descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
 #        or_record.event_type
 #    )
 
-# LIDO eventMethod [eventType/term="acquisition"]
-
-#    unless is_array(or_record.acquisition_method)
-#        move_field(or_record.acquisition_method, or_record.tmp)
-#        set_array(or_record.acquisition_method)
-#        move_field(or_record.tmp, or_record.acquisition_method.$append)
-#    end
-
-    # We'll have multiple eventMethods: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
-
-#    do list(path:or_record.acquisition_method, var:c)
-
-        # Value in Adlib
-
-#        if all_match(c.value, '.*\S.*')
-
-#            if all_match(or_record.acquisition_method_id, '.*\S.*')
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
-#                    c.value,
-#                    -conceptid: or_record.acquisition_method_id,
-#                    -type: local,
-#                    -source: Adlib,
-#                    -pref: preferred,
-#                    -lang: nl
-#                )
-
-#            else
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
-#                    c.value,
-#                    -pref: preferred,
-#                    -lang: nl
-#                )
-
-#            end
-
-#        end
-
-        # Corresponding value in AAT, not (yet) retrievable via API
-
-#        copy_field(c.value, c.aat)
-
-#        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
-
-#        if all_match(c.aat.aatterm, '.*\S.*')
-
-#            if all_match(c.aat.aaturi, '.*\S.*')
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
-#                    c.aat.aatterm,
-#                    -conceptid: c.aat.aaturi,
-#                    -type: purl,
-#                    -source: AAT,
-#                    -pref: alternate,
-#                    -lang: nl
-#                )
-
-#            else
-
-#                lido_term(
-#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
-#                    c.aat.aatterm,
-#                    -pref: alternate,
-#                    -lang: nl
-#                )
-
-#            end
-
-#        end
-
-#    end
-
 # LIDO eventActor [eventType/term="acquisition"]
 
-#    unless is_array(or_record.acquisition_source)
+#    unless is_array(or_record.acquisition_source) 
 #        move_field(or_record.acquisition_source, or_record.tmp)
 #        set_array(or_record.acquisition_source)
 #        move_field(or_record.tmp, or_record.acquisition_source.$append)
@@ -816,11 +920,12 @@
 
 #    do list (path:or_record.acquisition_source, var:c)
 
-#        if all_match(c, '.*\S.*')
+#        if all_match('c.acquisition\.source', '.*\S.*')
 
-#            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append)
-
-#            copy_field(c, descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.nameActorSet.appellationValue._)
+#            lido_basenameset(
+#                descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append.actorInRole.actor.nameActorSet,
+#                'c.acquisition\.source'
+#            )
 
 #        end
 
@@ -847,9 +952,178 @@
 
 #    end
 
+# LIDO eventMethod [eventType/term="acquisition"]
+
+#    unless is_array(or_record.acquisition_method)
+#        move_field(or_record.acquisition_method, or_record.tmp)
+#        set_array(or_record.acquisition_method)
+#        move_field(or_record.tmp, or_record.acquisition_method.$append)
+#    end
+
+#    unless is_array(or_record.acquisition_method_id)
+#        move_field(or_record.acquisition_method_id, or_record.tmp)
+#        set_array(or_record.acquisition_method_id)
+#        move_field(or_record.tmp, or_record.acquisition_method_id.$append)
+#    end
+
+#    do list (path: or_record.acquisition_method_id, var: c)
+#        copy_field(c, or_record.acquisition_method.$append.id)
+#    end
+
+#    assoc(or_record.acquisition_m, or_record.acquisition_method.*.id, or_record.acquisition_method.*)
+
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+
+#    do each (path:or_record.acquisition_m, var:c)
+
+        # Value in Adlib
+
+#        if all_match(c.value, '.*\S.*')
+
+#            if all_match(c.key, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
+#                    c.value,
+#                    -conceptid: c.key,
+#                    -type: local,
+#                    -source: Adlib,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$append,
+#                    c.value,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+        # Corresponding value in AAT, not (yet) retrievable via API
+
+#        copy_field(c.value, c.acquisition_aat)
+
+#        lookup_in_store(c.acquisition_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+
+#        if all_match(c.acquisition_aat.aatterm, '.*\S.*')
+
+#            if all_match(c.acquisition_aat.aaturi, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
+#                    c.acquisition_aat.aatterm,
+#                    -conceptid: c.acquisition_aat.aaturi,
+#                    -type: purl,
+#                    -source: AAT,
+#                    -pref: alternate,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMethod.$last,
+#                    c.acquisition_aat.aatterm,
+#                    -pref: alternate,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+#    end
+
+# LIDO eventDescriptionSet [eventType/term="acquisition"]
+
+#    unless is_array(or_record.acquisition_creditline)
+#        move_field(or_record.acquisition_creditline, or_record.tmp)
+#        set_array(or_record.acquisition_creditline)
+#        move_field(or_record.tmp, or_record.acquisition_creditline.$append)
+#    end
+
+#    do list (path:or_record.acquisition_creditline, var:c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_descriptivenote(
+#                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDescriptionSet,
+#                c
+#            )
+
+#        end
+
+#    end
+
+# LIDO eventName / date [eventType/term="exhibition"]
+
+#    add_field(or_record.event_type, "exhibition")
+
+#    unless is_array(or_record.exhibition)
+#        move_field(or_record.exhibition, or_record.tmp)
+#        set_array(or_record.exhibition)
+#        move_field(or_record.tmp, or_record.exhibition.$append)
+#    end
+
+#    do list (path:or_record.exhibition, var:c)
+
+#        lido_term(
+#            descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
+#            or_record.event_type
+#        )
+
+#        if all_match(c.exhibition, '.*\S.*')
+
+#            lido_basenameset(
+#                descriptiveMetadata.eventWrap.eventSet.$last.event.eventName,
+#                c.exhibition
+#            )
+
+#        end
+
+#        if all_match('c.exhibition\.date\.start', '.*\S.*')
+
+#            if all_match('c.exhibition\.date\.end', '.*\S.*')
+
+#                lido_date(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+#                    -earliest_date: 'c.exhibition\.date\.start',
+#                    -latest_date: 'c.exhibition\.date\.end'
+#                )
+            
+#            else
+
+#                lido_date(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+#                    -earliest_date: 'c.exhibition\.date\.start'
+#                )
+
+#            end
+
+#        else
+
+#            if all_match('c.exhibition\.date\.end', '.*\S.*')
+
+#                lido_date(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+#                    -latest_date: 'c.exhibition\.date\.end'
+#                )
+
+#            end
+
+#        end
+
+#    end
+
 # LIDO eventType [eventType/term="production"]
 
-    add_field(or_record.event_type, production)
+    add_field(or_record.event_type, "production")
     
     lido_term(
         descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
@@ -868,12 +1142,12 @@
 
         trim('c.creator\.qualifier')
 
-        if all_match(c.creator.value, '.*\S.*')
+        if all_match(c.creator, '.*\S.*')
 
             lido_actor(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append,
                 'c.creator\.lref',
-                c.creator.value,
+                c.creator,
                 -id_source: Adlib,
                 -id_type: local,
                 -name_pref: preferred
@@ -895,30 +1169,30 @@
 
         # Role. Work around. -role switch in lido_actor does not work correctly.
 
-        if all_match('c.creator\.role.value', '.*\S.*')
+        if all_match('c.creator\.role', '.*\S.*')
 
             lido_term(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.roleActor,
-                'c.creator\.role.value',
+                'c.creator\.role',
             )
 
         end
 
         # Add Persistent URI data to actor
 
-        copy_field(c.creator.value, c.creator.pid)
+        copy_field(c.creator, c.creator_pid)
 
-        downcase(c.creator.pid)
+        downcase(c.creator_pid)
 
-        lookup_in_store(c.creator.pid, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
+        lookup_in_store(c.creator_pid, DBI, data_source: "dbi:SQLite:/tmp/import.CREATORS_UTF8.sqlite")
 
         # Preferred label from Flemish Art Collection concordance database
 
-        if all_match(c.creator.pid._id, '.*\S.*')
+        if all_match(c.creator_pid._id, '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.nameActorSet.$last,
-                c.creator.pid.display_name,
+                c.creator_pid.display_name,
                 -value_pref: alternate
             )
 
@@ -926,33 +1200,33 @@
 
         # Creator Persistent URI's
 
-        if all_match(c.creator.pid.viaf_uri, '.*\S.*')
+        if all_match(c.creator_pid.viaf_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.viaf_uri,
+                c.creator_pid.viaf_uri,
                 -source: VIAF,
                 -type: purl
             )
 
         end
 
-        if all_match(c.creator.pid.rkd_uri, '.*\S.*')
+        if all_match(c.creator_pid.rkd_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.rkd_uri,
+                c.creator_pid.rkd_uri,
                 -source: RKD,
                 -type: purl
             )
 
         end
 
-        if all_match(c.creator.pid.wikidata_uri, '.*\S.*')
+        if all_match(c.creator_pid.wikidata_uri, '.*\S.*')
 
             lido_baseid(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$last.actorInRole.actor.actorID,
-                c.creator.pid.wikidata_uri,
+                c.creator_pid.wikidata_uri,
                 -source: Wikidata,
                 -type: purl
             )
@@ -1019,14 +1293,22 @@
 
                 end
 
+            else
+
+                add_field(or_record.displayDate, "incorrect date format")
+
             end
 
         end
 
-        lido_basevalue(
-            descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.displayDate,
-            or_record.displayDate
-        )
+        unless all_match(or_record.displayDate, "incorrect date format")
+
+            lido_basevalue(
+                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.displayDate,
+                or_record.displayDate
+            )
+
+        end
 
     end
 
@@ -1039,11 +1321,11 @@
 
         if all_match('d.production\.date\.start', '.*\S.*')
 
-            prepend('d.production\.date\.start', 'date')
+            prepend('d.production\.date\.start', '#date#')
 
             if all_match('d.production\.date\.start\.prec', '.*\S.*')
 
-                prepend('d.production\.date\.start\.prec', 'prec')
+                prepend('d.production\.date\.start\.prec', '#prec#')
                 paste('d.production\.date\.start','d.production\.date\.start','d.production\.date\.start\.prec',join_char:"")
 
             end
@@ -1054,11 +1336,11 @@
 
         if all_match('d.production\.date\.end', '.*\S.*')
 
-            prepend('d.production\.date\.end', 'date')
+            prepend('d.production\.date\.end', '#date#')
 
             if all_match('d.production\.date\.end\.prec', '.*\S.*')
 
-                prepend('d.production\.date\.end\.prec', 'prec')
+                prepend('d.production\.date\.end\.prec', '#prec#')
                 paste('d.production\.date\.end','d.production\.date\.end','d.production\.date\.end\.prec',join_char:"")
 
             end
@@ -1072,11 +1354,11 @@
     if all_match(or_record.earliest_dates.0, '.*\S.*')
 
         sort_field(or_record.earliest_dates)
-        if any_match(or_record.earliest_dates.0, 'date(.*)prec(.*)')
-            parse_text(or_record.earliest_dates.0, 'date(.*)prec(.*)')
+        if any_match(or_record.earliest_dates.0, '#date#(.*)#prec#(.*)')
+            parse_text(or_record.earliest_dates.0, '#date#(.*)#prec#(.*)')
         else
-            if any_match(or_record.earliest_dates.0, 'date(.*)')
-                parse_text(or_record.earliest_dates.0, 'date(.*)')
+            if any_match(or_record.earliest_dates.0, '#date#(.*)')
+                parse_text(or_record.earliest_dates.0, '#date#(.*)')
             end
         end
 
@@ -1085,11 +1367,11 @@
     if all_match(or_record.latest_dates.0, '.*\S.*')
 
         sort_field(or_record.latest_dates, reverse:1)
-        if any_match(or_record.latest_dates.0, 'date(.*)prec(.*)')
-            parse_text(or_record.latest_dates.0, 'date(.*)prec(.*)')
+        if any_match(or_record.latest_dates.0, '#date#(.*)#prec#(.*)')
+            parse_text(or_record.latest_dates.0, '#date#(.*)#prec#(.*)')
         else
-            if any_match(or_record.latest_dates.0, 'date(.*)')
-                parse_text(or_record.latest_dates.0, 'date(.*)')
+            if any_match(or_record.latest_dates.0, '#date#(.*)')
+                parse_text(or_record.latest_dates.0, '#date#(.*)')
             end
         end
 
@@ -1097,23 +1379,72 @@
 
     if all_match(or_record.earliest_dates.0.0, '.*\S.*')
 
-        if all_match(or_record.latest_dates.0.0, '.*\S.*')
+        if all_match(or_record.earliest_dates.0.1, '.*\S.*')
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -earliest_date: or_record.earliest_dates.0.0,
-                -earliest_date_type: or_record.earliest_dates.0.1,
-                -latest_date: or_record.latest_dates.0.0,
-                -latest_date_type: or_record.latest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.0, '.*\S.*')
+
+                if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -earliest_date_type: or_record.earliest_dates.0.1,
+                        -latest_date: or_record.latest_dates.0.0,
+                        -latest_date_type: or_record.latest_dates.0.1
+                    )
+
+                else
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -earliest_date_type: or_record.earliest_dates.0.1,
+                        -latest_date: or_record.latest_dates.0.0
+                    )
+
+                end
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -earliest_date: or_record.earliest_dates.0.0,
+                    -earliest_date_type: or_record.earliest_dates.0.1
+                )
+
+            end
 
         else
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -earliest_date: or_record.earliest_dates.0.0,
-                -earliest_date_type: or_record.earliest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.0, '.*\S.*')
+
+                if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -latest_date: or_record.latest_dates.0.0,
+                        -latest_date_type: or_record.latest_dates.0.1
+                    )
+
+                else
+
+                    lido_date(
+                        descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                        -earliest_date: or_record.earliest_dates.0.0,
+                        -latest_date: or_record.latest_dates.0.0
+                    )
+
+                end
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -earliest_date: or_record.earliest_dates.0.0,
+                )
+
+            end
 
         end
 
@@ -1121,11 +1452,22 @@
 
         if all_match(or_record.latest_dates.0.0, '.*\S.*')
 
-            lido_date(
-                descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
-                -latest_date: or_record.latest_dates.0.0,
-                -latest_date_type: or_record.latest_dates.0.1
-            )
+            if all_match(or_record.latest_dates.0.1, '.*\S.*')
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -latest_date: or_record.latest_dates.0.0,
+                    -latest_date_type: or_record.latest_dates.0.1
+                )
+
+            else
+
+                lido_date(
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventDate.date,
+                    -latest_date: or_record.latest_dates.0.0
+                )
+
+            end
 
         else
 
@@ -1163,18 +1505,18 @@
         copy_field(c, or_record.production_period.$append.id)
     end
 
-    assoc(or_record.period, or_record.production_period.*.value, or_record.production_period.*.id)
+    assoc(or_record.period, or_record.production_period.*.id, or_record.production_period.*)
 
     do each (path: or_record.period, var: c)
 
-        if all_match(c.key, '.*\S.*')
+        if all_match(c.value, '.*\S.*')
 
-            if all_match(c.value, '.*\S.*')
+            if all_match(c.key, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.periodName.$append,
-                    c.key,
-                    -conceptid: c.value,
+                    c.value,
+                    -conceptid: c.key,
                     -lang: nl,
                     -source: Adlib,
                     -type: local
@@ -1184,7 +1526,7 @@
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.periodName.$append,
-                    c.key,
+                    c.value,
                     -lang: nl
                 )
 
@@ -1196,13 +1538,19 @@
 
 # LIDO namePlaceSet [eventType/term="production"]
 
+    unless is_array(or_record.production)
+        move_field(or_record.production, or_record.tmp)
+        set_array(or_record.production)
+        move_field(or_record.tmp, or_record.production.$append)
+    end
+
     do list (path: or_record.production, var: c)
 
-        if all_match('c.production\.place.value', '.*\S.*')
+        if all_match('c.production\.place', '.*\S.*')
 
             lido_basenameset(
                 descriptiveMetadata.eventWrap.eventSet.$last.event.eventPlace.$append.place.namePlaceSet,
-                'c.production\.place.value',
+                'c.production\.place',
                 -value_pref: preferred,
                 -value_lang: nl
             )
@@ -1224,33 +1572,29 @@
 
 # LIDO termMaterialsTech [eventType/term="production"]
 
+    # Materials
+
     unless is_array(or_record.materials) 
         move_field(or_record.materials, or_record.tmp)
         set_array(or_record.materials)
         move_field(or_record.tmp, or_record.materials.$append)
     end
 
-    # We'll have multiple classifications: the corresponding value in AAT (type:alternate) and the value from the Adlib field object_name itself (type:preferred)
+    # We'll have multiple terms: the corresponding value in AAT (type:alternate) and the value from the Adlib field object_name itself (type:preferred)
 
     do list(path: or_record.materials, var: c)
 
         # Value in Adlib
 
-        if all_match(c.material.value, '.*\S.*')
+        if all_match(c.material, '.*\S.*')
 
-            # get full material string stored in the notes 
-
-            if all_match('c.material\.notes', '.*\S.*')
-
-                copy_field('c.material\.notes',descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.displayMaterialsTech.$append)
-
-            end 
+            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append.type, "material")
 
             if all_match('c.material\.lref', '.*\S.*')
 
                 lido_term(
-                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append,
-                    c.material.value,
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+                    c.material,
                     -conceptid: 'c.material\.lref',
                     -type: local,
                     -source: Adlib,
@@ -1261,8 +1605,8 @@
             else
 
                 lido_term(
-                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append,
-                    c.material.value,
+                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+                    c.material,
                     -pref: preferred,
                     -lang: nl
                 )
@@ -1273,18 +1617,18 @@
 
         # Corresponding value in AAT, not (yet) retrievable via API
 
-        copy_field(c.material.value, c.aat)
+        copy_field(c.material, c.material_aat)
 
-        lookup_in_store(c.aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+        lookup_in_store(c.material_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
 
-        if all_match(c.aat._id, '.*\S.*')
+        if all_match(c.material_aat._id, '.*\S.*')
 
-            if all_match(c.aat.aaturi, '.*\S.*')
+            if all_match(c.material_aat.aaturi, '.*\S.*')
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
-                    c.aat.aatterm,
-                    -conceptid: c.aat.aaturi,
+                    c.material_aat.aatterm,
+                    -conceptid: c.material_aat.aaturi,
                     -type: purl,
                     -source: AAT,
                     -pref: alternate,
@@ -1295,7 +1639,7 @@
 
                 lido_term(
                     descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
-                    c.aat.aatterm,
+                    c.material_aat.aatterm,
                     -pref: alternate,
                     -lang: nl
                 )
@@ -1305,6 +1649,47 @@
         end
 
     end
+
+    # Techniques
+
+#    unless is_array(or_record.technique)
+#        move_field(or_record.technique, or_record.tmp)
+#        set_array(or_record.technique)
+#        move_field(or_record.tmp, or_record.technique.$append)
+#    end
+
+#    do list(path:or_record.technique, var: c)
+
+#        if all_match(c.technique, '.*\S.*')
+
+#            add_field(descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$append.materialsTech.termMaterialsTech.$append.type, "technique")
+
+#            if all_match('c.technique\.lref', '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+#                    c.technique,
+#                    -conceptid: 'c.technique\.lref',
+#                    -type: local,
+#                    -source: Adlib,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.eventWrap.eventSet.$last.event.eventMaterialsTech.$last.materialsTech.termMaterialsTech.$last,
+#                    c.technique,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+#    end
 
 # LIDO displayMaterialsTech [eventType/term="production"]
 
@@ -1327,10 +1712,185 @@
 
     end
 
+# LIDO eventType [eventType/term="provenance"]
+
+#    add_field(or_record.event_type, provenance)
+
+#    lido_term(
+#        descriptiveMetadata.eventWrap.eventSet.$append.event.eventType,
+#        or_record.event_type
+#    )
+
+# LIDO eventActor [eventType/term="provenance"]
+
+#    unless is_array(or_record.current_owner) 
+#        move_field(or_record.current_owner, or_record.tmp)
+#        set_array(or_record.current_owner)
+#        move_field(or_record.tmp, or_record.current_owner.$append)
+#    end
+
+#    do list (path: or_record.current_owner, var: c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_basenameset(
+#                descriptiveMetadata.eventWrap.eventSet.$last.event.eventActor.$append.actorInRole.actor.nameActorSet,
+#                c
+#            )
+
+#        end
+
+#    end
+
 
 ## LIDO objectRelationWrap
 
 # LIDO subjectConcept / subjectEvent / subjectPlace
+
+    # Content motif general
+
+    unless is_array(or_record.content_motif_general)
+        move_field(or_record.content_motif_general, or_record.tmp)
+        set_array(or_record.content_motif_general)
+        move_field(or_record.tmp, or_record.content_motif_general.$append)
+    end
+
+    unless is_array(or_record.content_motif_general_id)
+        move_field(or_record.content_motif_general_id, or_record.tmp)
+        set_array(or_record.content_motif_general_id)
+        move_field(or_record.tmp, or_record.content_motif_general_id.$append)
+    end
+
+    do list(path:or_record.content_motif_general_id, var:c)
+        copy_field(c, or_record.content_motif_general.$append.id)
+    end
+
+    assoc(or_record.general_motif, or_record.content_motif_general.*.id, or_record.content_motif_general.*)
+
+    # We'll have multiple terms for the type "content-motif-general": the corresponding value in AAT (type:alternate) and the value from Adlib (type:preferred)
+
+    do each(path:or_record.general_motif, var:c)
+
+        # Value in Adlib
+
+        if all_match(c.value, '.*\S.*')
+
+            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "content-motif-general")
+
+            if all_match(c.key, '.*\S.*')
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+                    c.value,
+                    -conceptid: c.key,
+                    -type: local,
+                    -source: Adlib,
+                    -pref: preferred,
+                    -lang: nl
+                )
+
+            else
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+                    c.value,
+                    -pref: preferred,
+                    -lang: nl
+                )
+
+            end
+
+        end
+
+        # Corresponding value in AAT, not (yet) retrievable via API
+
+        copy_field(c.value, c.general_motif_aat)
+
+        lookup_in_store(c.general_motif_aat, DBI, data_source: "dbi:SQLite:/tmp/import.AAT_UTF8.sqlite")
+
+        if all_match(c.general_motif_aat.aatterm, '.*\S.*')
+
+            if all_match(c.general_motif_aat.aaturi, '.*\S.*')
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$last,
+                    c.general_motif_aat.aatterm,
+                    -conceptid: c.general_motif_aat.aaturi,
+                    -type: purl,
+                    -source: AAT,
+                    -pref: alternate,
+                    -lang: nl
+                )
+
+            else
+
+                lido_term(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$last,
+                    c.general_motif_aat.aatterm,
+                    -pref: alternate,
+                    -lang: nl
+                )
+
+            end
+
+        end
+
+    end
+
+    # Content motif specific
+
+#    unless is_array(or_record.content_motif_specific)
+#        move_field(or_record.content_motif_specific, or_record.tmp)
+#        set_array(or_record.content_motif_specific)
+#        move_field(or_record.tmp, or_record.content_motif_specific.$append)
+#    end
+
+#    unless is_array(or_record.content_motif_specific_id)
+#        move_field(or_record.content_motif_specific_id, or_record.tmp)
+#        set_array(or_record.content_motif_specific_id)
+#        move_field(or_record.tmp, or_record.content_motif_specific_id.$append)
+#    end
+
+#    do list(path:or_record.content_motif_specific_id, var:c)
+#        copy_field(c, or_record.content_motif_specific.$append.id)
+#    end
+
+#    assoc(or_record.specific_motif, or_record.content_motif_specific.*.id, or_record.content_motif_specific.*)
+
+#    do each(path:or_record.specific_motif, var:c)
+
+#        if all_match(c.value, '.*\S.*')
+
+#            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "content-motif-specific")
+
+#            if all_match(c.key, '.*\S.*')
+
+#                lido_term(
+#                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+#                    c.value,
+#                    -conceptid: c.key,
+#                    -type: local,
+#                    -source: Adlib,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            else
+
+#                lido_term(
+#                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+#                    c.value,
+#                    -pref: preferred,
+#                    -lang: nl
+#                )
+
+#            end
+
+#        end
+
+#    end
+
+    # Depicted subject
 
     unless is_array(or_record.depicted_subject) 
         move_field(or_record.depicted_subject, or_record.tmp)
@@ -1340,15 +1900,13 @@
 
     do list(path:or_record.depicted_subject, var:c)
 
-        if all_match('c.content\.subject.value', '.*\S.*')
+        if all_match('c.content\.subject', '.*\S.*')
 
             if all_match('c.content\.subject\.type.value.2.content', 'geografie')
 
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectPlace.$append)
-
                 lido_basenameset(
-                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectPlace.$last.place.namePlaceSet,
-                    'c.content\.subject.value'
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectPlace.$append.place.namePlaceSet,
+                    'c.content\.subject'
                 )
 
                 if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1366,13 +1924,11 @@
 
                 if all_match('c.content\.subject\.type.value.2.content', 'gebeurtenis')
 
-                    add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$append)
-
                     set_field(or_record.event_type, event)
                     set_field(or_record.event_type_URI, 'http://www.cidoc-crm.org/Entity/e5-event/version-6.2')
 
                     lido_term(
-                        descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventType,
+                        descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectEvent.$append.event.eventType,
                         or_record.event_type,
                         -conceptid: or_record.event_type_URI,
                         -type: purl,
@@ -1381,7 +1937,7 @@
 
                     lido_basenameset(
                         descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventName,
-                        'c.content\.subject.value'
+                        'c.content\.subject'
                     )
 
                     if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1399,13 +1955,11 @@
 
                     if all_match('c.content\.subject\.type.value.2.content', 'activiteit')
 
-                        add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$append)
-
                         set_field(or_record.event_type, activity)
                         set_field(or_record.event_type_URI, 'http://www.cidoc-crm.org/Entity/e7-activity/version-6.2')
 
                         lido_term(
-                            descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventType,
+                            descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectEvent.$append.event.eventType,
                             or_record.event_type,
                             -conceptid: or_record.event_type_URI,
                             -type: purl,
@@ -1414,7 +1968,7 @@
 
                         lido_basenameset(
                             descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectEvent.$last.event.eventName,
-                            'c.content\.subject.value'
+                            'c.content\.subject'
                         )
 
                         if all_match('c.content\.subject\.lref', '.*\S.*')
@@ -1433,8 +1987,8 @@
                         if all_match('c.content\.subject\.lref', '.*\S.*')
 
                             lido_term(
-                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
-                                'c.content\.subject.value',
+                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectConcept.$append,
+                                'c.content\.subject',
                                 -conceptid: 'c.content\.subject\.lref',
                                 -type: local,
                                 -source: Adlib
@@ -1443,8 +1997,8 @@
                         else
 
                             lido_term(
-                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
-                                'c.content\.subject.value'
+                                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectConcept.$append,
+                                'c.content\.subject'
                             )
 
                         end
@@ -1459,7 +2013,32 @@
 
     end
 
+    # Associated subject
+
+#    unless is_array(or_record.associated_subject)
+#        move_field(or_record.associated_subject, or_record.tmp)
+#        set_array(or_record.associated_subject)
+#        move_field(or_record.tmp, or_record.associated_subject.$append)
+#    end
+
+#    do list(path:or_record.associated_subject, var:c)
+
+#        if all_match('c.association\.subject', '.*\S.*')
+
+#            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "associated")
+
+#            lido_term(
+#                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectConcept.$append,
+#                'c.association\.subject'
+#            )
+
+#        end
+
+#    end
+
 # LIDO subjectActor
+
+    # Depicted person
 
     unless is_array(or_record.depicted_person) 
         move_field(or_record.depicted_person, or_record.tmp)
@@ -1469,19 +2048,21 @@
 
     do list(path:or_record.depicted_person, var:c)
 
-        if all_match('c.content\.person\.name.value', '.*\S.*')
+        if all_match('c.content\.person\.name', '.*\S.*')
 
-            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$append)
-
-            copy_field('c.content\.person\.name.value', descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.nameActorSet.appellationValue._)
+            lido_basenameset(
+                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectActor.$append.actor.nameActorSet,
+                'c.content\.person\.name'
+            )
 
             if all_match('c.content\.person\.name\.lref', '.*\S.*')
 
-                copy_field('c.content\.person\.name\.lref', descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID._)
-
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID.type, "local")
-
-                add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID.source, "Adlib")
+                lido_baseid(
+                    descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.$last.actor.actorID,
+                    'c.content\.person\.name\.lref',
+                    -type: local,
+                    -source: Adlib
+                )
 
             end
 
@@ -1489,9 +2070,111 @@
 
     end
 
+    # Associated person
+
+#    unless is_array(or_record.associated_person)
+#        move_field(or_record.associated_person, or_record.tmp)
+#        set_array(or_record.associated_person)
+#        move_field(or_record.tmp, or_record.associated_person.$append)
+#    end
+
+#    do list(path:or_record.associated_person, var:c)
+
+#        if all_match('c.association\.person', '.*\S.*')
+
+#            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "associated")
+
+#            lido_basenameset(
+#                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectActor.actor.nameActorSet,
+#                'c.association\.person'
+#            )
+
+#        end
+
+#    end
+
+# LIDO subjectDate
+
+    # Depicted period
+
+#    unless is_array(or_record.depicted_period)
+#        move_field(or_record.depicted_period, or_record.tmp)
+#        set_array(or_record.depicted_period)
+#        move_field(or_record.tmp, or_record.depicted_period.$append)
+#    end
+
+#    do list(path:or_record.depicted_period, var:c)
+
+#        if all_match(c, '.*\S.*')
+
+#            lido_basevalue(
+#                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.subjectDate.displayDate,
+#                c
+#            )
+
+#        end
+
+#    end
+
+    # Associated period
+
+#    unless is_array(or_record.associated_period)
+#        move_field(or_record.associated_period, or_record.tmp)
+#        set_array(or_record.associated_period)
+#        move_field(or_record.tmp, or_record.associated_period.$append)
+#    end
+
+#    do list(path:or_record.associated_period, var:c)
+
+#        if all_match('c.association\.period', '.*\S.*')
+
+#            add_field(descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$append.subject.type, "associated")
+
+#            lido_basevalue(
+#                descriptiveMetadata.objectRelationWrap.subjectWrap.subjectSet.$last.subject.subjectDate.displayDate,
+#                'c.association\.period'
+#            )
+
+#        end
+
+#    end
+
 
 
 ### LIDO administrativeMetadata
+
+## LIDO rightsWorkWrap
+
+# LIDO creditLine
+
+#    do list(path: or_record.rights, var: c)
+
+#        if all_match('c.rights\.notes', '.*\S.*')
+
+#            lido_basevalue(
+#                administrativeMetadata.rightsWorkWrap.rightsWorkSet.$append.creditLine,
+#                'c.rights\.notes'
+#            )
+
+#        end
+
+#    end
+
+    do list(path: or_record.object_number, var: c)
+
+        lookup_in_store(c, DBI, data_source: 'dbi:SQLite:/tmp/import.RIGHTS.sqlite')
+
+        if all_match(c.rights, '.*\S.*')
+
+            lido_basevalue(
+                administrativeMetadata.rightsWorkWrap.rightsWorkSet.creditLine,
+                c.rights
+            )
+
+        end
+
+    end
+
 
 ## LIDO recordWrap
 
@@ -1499,7 +2182,7 @@
 
     do list(path:or_record.pids, var: c)
 
-        if all_match('c.digital_reference\.description.value', 'datapid')
+        if all_match('c.digital_reference\.description', 'datapid')
 
             if all_match(c.digital_reference, '.*\S.*')
 
@@ -1570,11 +2253,11 @@
 
     do list(path: or_record.institution, var: c)
 
-        if all_match(c.value, '.*\S.*')
+        if all_match(c, '.*\S.*')
 
             lido_basenameset(
-                administrativeMetadata.recordWrap.recordSource.legalBodyName.$append,
-                c.value
+                administrativeMetadata.recordWrap.recordSource.legalBodyName,
+                c
             )
 
         end
@@ -1595,33 +2278,17 @@
 
     do list(path:or_record.pids, var: c)
 
-        if all_match('c.digital_reference\.description.value', 'representationpid')
+        if all_match('c.digital_reference\.description', 'representationpid')
 
             if all_match(c.digital_reference, '.*\S.*')
 
                 copy_field(c.digital_reference, administrativeMetadata.resourceWrap.resourceSet.resourceID._)
                 add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.type, "purl")
+                add_field(administrativeMetadata.resourceWrap.resourceSet.resourceID.label, "representationPID")
 
                 copy_field(c.digital_reference, administrativeMetadata.resourceWrap.resourceSet.resourceRepresentation.linkResource._)
 
             end
-
-        end
-
-    end
-
-# LIDO rightsResource
-
-    do list(path: or_record.object_number, var: c)
-
-        lookup_in_store(c, DBI, data_source: 'dbi:SQLite:/tmp/import.RIGHTS.sqlite')
-
-        if all_match(c.rights, '.*\S.*')
-
-            lido_basenameset(
-                administrativeMetadata.resourceWrap.resourceSet.rightsResource.rightsHolder.legalBodyName,
-                c.rights
-            )
 
         end
 

--- a/pipelines/arthub.ini
+++ b/pipelines/arthub.ini
@@ -3,4 +3,4 @@ plugin = Solr
 
 [plugin_indexer_Solr]
 file_name = '/tmp/bulk_raw.json'
-request_handler = 'http://datahub.box:8983/solr/blacklight-core/update/json'
+request_handler = 'http://localhost:8983/solr/blacklight-core/update/json'

--- a/scripts/arthub-index.sh
+++ b/scripts/arthub-index.sh
@@ -1,11 +1,17 @@
-#/bin/bash
+#!/bin/bash
 
-usage() { echo "Usage: $0 [-e <string>]" 1>&2; exit 1; }
+usage() {
+	echo "Usage: $0 -e <string> -l <string>" 1>&2;
+	exit 1;
+}
 
-while getopts ":e:" o; do
+while getopts ":e:l:" o; do
     case "${o}" in
         e)
-            e=${OPTARG}
+            e="${OPTARG}"
+            ;;
+        l)
+            l="${OPTARG}"
             ;;
         *)
             usage
@@ -14,14 +20,27 @@ while getopts ":e:" o; do
 done
 shift $((OPTIND-1))
 
-if [ -z "${e}" ]; then
+if [ -z "${e}" -o -z "${l}" ]; then
     usage
+fi
+
+if [ ! -f "${l}" -o ! -r "${l}" ]; then
+	if [[ "$l" =~ ^[a-z]{2,3}$ ]]; then
+		l="../fixes/datahub-oai-to-blacklight-solr-${l}.fix"
+		if [ ! -f "${l}" -o ! -r "${l}" ]; then
+			echo "The fix file ${l} does not exist or is not readable."
+			exit 1
+		fi
+	else
+		echo "The fix file ${l} does not exist or is not readable."
+		exit 1
+    fi
 fi
 
 # Fetch data from the OAI endpoint
 
 echo "Fetching data"
-catmandu convert OAI --url $e --handler lido to JSON --fix ../datahub-oai-to-blacklight-solr.fix > /tmp/bulk.json
+catmandu convert OAI --url "$e" --handler lido to JSON --fix "$l" > /tmp/bulk.json
 
 # Fetch XML raw data from the OAI endpoint and add it to the JSON blob.
 

--- a/scripts/arthub-index.sh
+++ b/scripts/arthub-index.sh
@@ -26,7 +26,7 @@ fi
 
 if [ ! -f "${l}" -o ! -r "${l}" ]; then
 	if [[ "$l" =~ ^[a-z]{2,3}$ ]]; then
-		l="../fixes/datahub-oai-to-blacklight-solr-${l}.fix"
+		l="../datahub-oai-to-blacklight-solr-${l}.fix"
 		if [ ! -f "${l}" -o ! -r "${l}" ]; then
 			echo "The fix file ${l} does not exist or is not readable."
 			exit 1


### PR DESCRIPTION
These commits include critical changes to make the Datahub compatible with the latest changes to the XML structure in Adlib, but also renames Dutch keywords to English as agreed upon (objectnummer -> object-number, objectcategorie -> object-category etc.).